### PR TITLE
fix Capillary.jl to include EHnm and TE/TM modes

### DIFF
--- a/src/Capillary.jl
+++ b/src/Capillary.jl
@@ -76,15 +76,17 @@ function zdw(a; gas::Symbol, pressure, n=1, m=1)
 end
 
 function Aeff(a, n=1, m=1)
-    unm = besselj_zero(n-1, m)
-    return 2π*a^2*(hquadrature(r-> r*besselj(n-1, r*unm)^2, 0, 1)[1]^2
-                   / hquadrature(r-> r*besselj(n-1, r*unm)^4, 0, 1)[1])
+    nJ = n > 0 ? n-1 : 2 # n=0 -> TE/TM modes so n-1 should be 1
+    unm = besselj_zero(nJ, m)
+    return 2π*a^2*(hquadrature(r-> r*besselj(nJ, r*unm)^2, 0, 1)[1]^2
+    / hquadrature(r-> r*besselj(nJ, r*unm)^4, 0, 1)[1])
 end
 
 function modefield(a, n=1, m=1)
-    unm = besselj_zero(n-1, m)
-    norm = c*ε_0*π*hquadrature(r-> r*besselj(n-1, r*unm/a)^2, 0, a)[1]
-    return r -> @. besselj(0, r*unm/a)/sqrt(norm)
+    nJ = n > 0 ? n-1 : 2 # n=0 -> TE/TM modes so n-1 should be 1
+    unm = besselj_zero(nJ, m)
+    norm = c*ε_0*π*hquadrature(r-> r*besselj(nJ, r*unm/a)^2, 0, a)[1]
+    return r -> @. besselj(nJ, r*unm/a)/sqrt(norm)
 end
 
 function mode_average(a, n=1, m=1)


### PR DESCRIPTION
This is starting to fix #15 and includes all EHnm modes. transverse modes to follow

(also using this test some GitHub features)