### PR TITLE
fix ionisation fraction integral in PlasmaCumtrapz

### DIFF
--- a/src/Nonlinear.jl
+++ b/src/Nonlinear.jl
@@ -71,7 +71,7 @@ end
 
 function (Plas::PlasmaCumtrapz)(out, E)
     Plas.ratefunc(Plas.rate, E)
-    Maths.cumtrapz!(Plas.fraction, Plas.t, Plas.rate)
+    Maths.cumtrapz!(Plas.fraction, Plas.rate, Plas.δt)
     @. Plas.fraction = 1-exp(-Plas.fraction)
     @. Plas.phase = Plas.fraction * e_ratio * E
     Maths.cumtrapz!(Plas.J, Plas.phase, Plas.δt)


### PR DESCRIPTION
The order of (y, x) arguments in one of the calls to Maths.cumtrapz! was incorrect. This does not appear to change anything in the examples run so far, likely because of the frequency windowing. 

In any case it's fixed now. It was also integrating with the full time axis rather than assuming a fixed step δt, so this should improve performance just a little bit.