### PR TITLE
Avoid git error when Luna is installed as a package

### DIFF
--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -3,32 +3,30 @@ import Dates
 
 function git_commit()
     wd = dirname(@__FILE__)
-    commit = read(`git -C $wd describe --always --tags --dirty`, String)
-    commit = commit[1:end-1] # Strip newline off the end
-end
-
-function git_isdirty()
-    wd = dirname(@__FILE__)
-    d = read(`git -C $wd diff --name-only`)
-    return length(d) > 0
+    try
+        commit = read(`git -C $wd describe --always --tags --dirty`, String)
+        commit = commit[1:end-1] # Strip newline off the end
+    catch
+        "unavailable (Luna is not checkout out for development)"
+    end
 end
 
 function git_branch()
-    wd = dirname(@__FILE__)
-    b = read(`git -C $wd rev-parse --abbrev-ref HEAD`, String)
-    return b[1:end-1] # Strip newline off the end
+    try
+        wd = dirname(@__FILE__)
+        b = read(`git -C $wd rev-parse --abbrev-ref HEAD`, String)
+        return b[1:end-1] # Strip newline off the end
+    catch
+        "unavailable (Luna is not checkout out for development)"
+    end
 end
 
 function sourcecode()
     src = dirname(@__FILE__)
     luna = dirname(src)
     out = "#= Date: $(Dates.now())\n"
-    try
-        out *= "git branch: $(git_branch())\n"
-        out *= "git commit: $(git_commit())\n"
-    catch
-        out *= "(Luna is not checked out for development, git version unavailable)\n\n"
-    end
+    out *= "git branch: $(git_branch())\n"
+    out *= "git commit: $(git_commit())\n"
     out *= "hostname: $(gethostname())\n"
     out *= "=#"
     for folder in (src, luna)


### PR DESCRIPTION
This addresses some of #79 

Wraps the `git` commands in a `try` block and replaces the commit and branch with a message if it fails. Also adds the working directory to the `git_branch()` function properly (this was simply an oversight).