### PR TITLE
Bringing back arbitrary and delegated modes

### DIFF
--- a/src/Modes.jl
+++ b/src/Modes.jl
@@ -333,6 +333,9 @@ for those which are overwritten
 The functions given should have the **same signature** as the mode methods, i.e. take
 an `AbstractMode` as their first argument, **even if** they do not do anything with it. This
 is to ensure that the delegated functions can access the data of the wrapped mode if necessary.
+
+To override `neff` with functions for `α` and `β`, create the `neff` function using
+[`neff_from_αβ`](@ref).
 """
 function delegated(mode; kwargs...)
     dmode = DelegatedMode(mode)
@@ -367,6 +370,9 @@ Create an arbitrary mode, which takes its methods from given functions.
 The functions given should have the same signature as defined `Luna.Modes`, **except** that
 the first argument (the `AbstractMode`) is omitted, e.g. for `neff` the function should be
 of the form `n(ω; z) = ...`
+
+To define `neff` with functions for `α` and `β`, create the `neff` function using
+[`neff_from_αβ`](@ref).
 """
 function arbitrary(;kwargs...)
     dmode = DelegatedMode(nothing)
@@ -389,5 +395,12 @@ function arbitrary(;kwargs...)
     end
     dmode
 end
+
+"""
+    neff_from_αβ(α, β)
+
+Create a closure converting the functions `α(ω; z)` and `β(ω; z)` into an effective index.
+"""
+neff_from_αβ(α, β) = (ω; z=0) -> c/ω * (β(ω; z=z) + 0.5im*α(ω; z=z))
 
 end

--- a/test/test_modes.jl
+++ b/test/test_modes.jl
@@ -1,4 +1,4 @@
-import Test: @test, @testset
+import Test: @test, @testset, @test_throws
 import FunctionZeros: besselj_zero
 import SpecialFunctions: besselj
 import LinearAlgebra: norm
@@ -29,13 +29,20 @@ import Luna.PhysData: wlfreq
     n(ω; z=0) = 1.0 + 3.0im
     m3 = Modes.arbitrary(neff=n,
                          dimlimits=(;z=0)->(:polar, (0.0, 0.0), (100e-6, 2π)),
-                         field=(;z)->nothing,
                          Aeff=(;z=0) -> 1e-5,
                          N=(;z=0) -> 1)
     @test Modes.α(m3, 1.5e15) == 2*3*1.5e15/PhysData.c
     @test Modes.β(m3, 1.5e15) == 1.5e15/PhysData.c
     @test Modes.Aeff(m3) == 1e-5
     @test Modes.N(m3) == 1
+    @test_throws ErrorException Modes.field(m3, (0.0, 0.0))
+
+    m4 = Modes.arbitrary(neff=Modes.neff_from_αβ((ω; z=0) -> 6*ω/PhysData.c,
+                                                 (ω; z=0) -> ω/PhysData.c))
+    @test Modes.α(m4, 1.5e15) ≈ 2*3*1.5e15/PhysData.c
+    @test Modes.β(m4, 1.5e15) ≈ 1.5e15/PhysData.c
+    @test Modes.neff(m4, 1.5e15) ≈ 1.0 + 3.0im
+    @test Modes.neff(m4, 1.5e15) ≈ 1.0 + 3.0im
 end
 
 @testset "overlap" begin


### PR DESCRIPTION
Now without macros. The simplest solution of just having a struct storing functions makes it very awkward to overwrite methods that depend on other methods (e.g. `Aeff`) so this is slightly more complicated but works.

Question: do we want to be able to define `α` and `β` instead of `neff`? Since they give the same information this would be a bit more work but could be done. 