### PR TITLE
Add missing mkpath for cachedir

### DIFF
--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -63,6 +63,7 @@ end
 function loadFFTwisdom()
     fpath = joinpath(cachedir(), "FFTWcache")
     lockpath = joinpath(cachedir(), "FFTWlock")
+    isdir(cachedir()) || mkpath(cachedir())
     if isfile(fpath)
         Logging.@info("Found FFTW wisdom at $fpath")
         pidlock = mkpidlock(lockpath)


### PR DESCRIPTION
The GitHub action now runs, but an early test fails because `load_FFT_wisdom` is missing a check to make sure the cache directory exists.

With this PR the test suite now runs on my machine even if I hide `~/.luna` just before starting.

The test suite takes about 30 minutes right now. Until June we have 10,000 minutes per month so 300 runs, which should be plenty. After that it goes down to 3,000.