### PR TITLE
pretty-printing for params

### DIFF
--- a/src/Tools.jl
+++ b/src/Tools.jl
@@ -75,8 +75,8 @@ paramfields = (:E, :τfw, :τ0, :ω, :λ, :material, :P, :T, :shape,:P0, :β2, :
 
 function show(io::IO, p::NamedTuple{paramfields, vT}) where vT
     mode = "MODE:\n  $(p.mode)"
-    fill = @sprintf("FILL:\n  %.1f bar %s, Pcr = %.1e, γ = %.1e, n2 = %.1e",
-                     p.P, p.material, p.Pcr, p.γ, p.n2)
+    fill = @sprintf("FILL:\n  %.1f bar %s, Pcr = %.1e W, γ = %.1e (Wm)^-1, n2 = %.1e cm^2/W",
+                     p.P, p.material, p.Pcr, p.γ, p.n2*1e4)
     wg = @sprintf("WAVEGUIDE:\n  Aeff = %.1e m^2, Lloss = %.1e m", p.Aeff, p.Lloss)
     pulse = @sprintf("PULSE:\n  %.2e J, %.2e s @ %.1f nm (shape: %s)",
                       p.E, p.τfw, p.λ*1e9, p.shape)
@@ -84,7 +84,7 @@ function show(io::IO, p::NamedTuple{paramfields, vT}) where vT
                           p.β2, p.λ*1e9, p.zdw*1e9)
     intensity = @sprintf("INTENSITY:\n  %.1e W/cm^2", p.I0*1e-4)
     power = @sprintf("POWER:\n  %.1e W (%.4f of Pcr)", p.P0, p.P0/p.Pcr)
-    sol = @sprintf("SOLITON:\n  Ld = %.1e, Lnl = %.1e, Lfiss = %.1e, N = %.2f",
+    sol = @sprintf("SOLITON:\n  Ld = %.1e m, Lnl = %.1e m, Lfiss = %.1e m, N = %.2f",
                    p.Ld, p.Lnl, p.Lfiss, p.N)
     out = join((mode, wg, fill, pulse, dispersion, power, intensity, sol), "\n")
     print(io, out)


### PR DESCRIPTION
Makes `Tools.params` show its result in a more readable form:

```julia
julia> p = Tools.capillary_params(250e-6, 10e-15, 1800e-9, 100e-6, :HeJ; P=9)
MODE:
  MarcatilliMode{HE11, a(z=0)=0.0001, loss=true, model=full}
WAVEGUIDE:
  Aeff = 1.5e-08 m^2, Lloss = 7.1e-01 m
FILL:
  9.0 bar HeJ, Pcr = 1.5e+11 W, γ = 7.4e-10 (Wm)^-1, n2 = 3.2e-20 cm^2/W
PULSE:
  2.50e-04 J, 1.00e-14 s @ 1800.0 nm (shape: sech)
DISPERSION:
  -1.48e-28 s^2/m @ 1800.0 nm, ZDW = 701.0 nm
POWER:
  2.2e+10 W (0.1440 of Pcr)
INTENSITY:
  1.5e+14 W/cm^2
SOLITON:
  Ld = 2.2e-01 m, Lnl = 6.1e-02 m, Lfiss = 1.2e-01 m, N = 1.89
```