### PR TITLE
Scan output

### DIFF
--- a/test/test_scans.jl
+++ b/test/test_scans.jl
@@ -44,7 +44,7 @@ push!(ARGS, "--range", "1:4")
 @test __SCAN__.name == "scantest"
 @test !__SCAN__.parallel
 
-@scanvar dummy = range(1, length=10)
+@scanvar dummy = collect(range(1, length=10))
 @test __SCAN__.vars[:dummy] == dummy
 @test __SCAN__.values[dummy] == dummy
 
@@ -59,7 +59,7 @@ end
 push!(ARGS, "--batch", "1,3")
 @scaninit "scantest"
 @test __SCAN__.mode == :batch
-@scanvar dummy = range(1, length=10)
+@scanvar dummy = collect(range(1, length=10))
 @test __SCAN__.batch == (1, 3)
 @test __SCAN__.idcs == [1, 4, 7, 10]
 @scan begin
@@ -88,7 +88,7 @@ push!(ARGS, "--local")
     em = fill(1.0*slength, (2, slength))
     stats = Dict("energy" => e, "energym" => em)
     xx, yy = $x, $y
-    Output.@scansave(out, stats, keyword=[xx, yy])
+    Output.@scansave(Eω=out, stats=stats, keyword=[xx, yy])
 end
 HDF5.h5open("scantest_collected.h5", "r") do file
     @test read(file["scanvariables"]["x"]) == x
@@ -122,4 +122,24 @@ rm("scantest_collected.h5")
 end
 catch
 rm("scantest_collected.h5")
+end
+
+@testset "ScanHDF5Output" begin
+for _ in eachindex(ARGS)
+    pop!(ARGS)
+end
+push!(ARGS, "--range", "1:4")
+@scaninit "scantest"
+@scanvar var1 = collect(range(1, length=10))
+@scanvar var2 = collect(1:20)
+@scan begin
+    out = Output.@ScanHDF5Output(0, 1, 10)
+    @test out["meta"]["scanarrays"]["var1"] == var1
+    @test out["meta"]["scanarrays"]["var2"] == var2
+    @test out["meta"]["scanvars"]["var1"] == $var1
+    @test out["meta"]["scanvars"]["var2"] == $var2
+    @test out["meta"]["scanshape"] == [length(var1), length(var2)]
+    @test out["meta"]["scanorder"] == ["var1", "var2"]
+    rm(out.fpath)
+end
 end


### PR DESCRIPTION
1. Closes #172 by saving more information about the scan in each file when using `@ScanHDF5Output`, including the scan grids and scan shape. See `test_output.jl` (last testset) for how this works.

2. Fixes a bug in `scansave` (wrong chunk dimensions) which caused a dramatic slowdown. Now as fast as would be expected.