### PR TITLE
HDF5 compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -48,3 +48,4 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 FiniteDifferences = "0.11"
+HDF5 = "0.13"


### PR DESCRIPTION
Updating to `HDF5` v0.14 causes two things to happen:
1. Lots of deprecation warnings due to syntax changes
2. Loading long strings (such as the "sourcecode" field) takes extremely long and essentially stops Luna from running with `HDF5Output`s. (see https://github.com/JuliaIO/HDF5.jl/issues/742)

Until we/they can sort this out, we should keep `HDF5` at v0.13