### PR TITLE
Conversion from missing to NaN in all ZDW stats

### DIFF
--- a/src/Stats.jl
+++ b/src/Stats.jl
@@ -440,12 +440,12 @@ end
 
 # For constant linop, ZDW is also constant
 function zdw_linop(mode::Modes.AbstractMode, linop::AbstractArray)
-    zdw = Modes.zdw(mode)
+    zdw = missnan(Modes.zdw(mode))
     (d, Eω, Et, z, dz) -> d["zdw"] = zdw
 end
 
 function zdw_linop(modes, linop::AbstractArray)
-    zdw = [Modes.zdw(mode) for mode in modes]
+    zdw = [missnan(Modes.zdw(mode)) for mode in modes]
     (d, Eω, Et, z, dz) -> d["zdw"] = zdw
 end
 


### PR DESCRIPTION
For low gas pressure and high-order modes, the ZDW can be too short for `Modes.zdw` to find, so it returns `missing`. This needs to be converted to a `Float` to be appended to arrays. This is already done for the `Stats.zdw` function, but not for the simple constant-ZDW functions used by `Stats.default`. 