### PR TITLE
flush stderr during propagation

### DIFF
--- a/src/RK45.jl
+++ b/src/RK45.jl
@@ -55,6 +55,7 @@ function solve(s, tmax; stepfun=donothing!, output=false, outputN=201,
                     s.tn/tmax*100, Dates.format(etad, "HH:MM:SS"), s.dt, s.err, repeated_tot)
             end
             tic = Dates.now()
+            flush(stderr)
         end
         if ok
             if output


### PR DESCRIPTION
This helps to keep track of progress on the workstation. Currently the output is cached and it is impossible to see how far through the propagation we are.