### PR TITLE
linear and nonlinear data for oxygen

### DIFF
--- a/src/PhysData.jl
+++ b/src/PhysData.jl
@@ -567,6 +567,8 @@ function ionisation_potential(material; unit=:SI)
         Ip = 0.5726
     elseif material == :H2
         Ip = 0.5669
+    elseif material == :O2
+        Ip = 0.443553
     else
         throw(DomainError(material, "Unknown material $material"))
     end


### PR DESCRIPTION
Dispersion formula from "Comment on “Precision refractive index measurements of air, 𝖭𝟤, 𝖮𝟤, Ar, and 𝖢𝖮𝟤 with a frequency comb”", https://doi.org/10.1364/AO.50.006484

Nonlinear refractive index from "Measurement of the nonlinear refractive index of air constituents at mid-infrared wavelengths ", https://doi.org/10.1364/OL.40.005794, Table 1, taking the value at 800 nm (but as the authors note, there is very little dispersion) 