### PR TITLE
Make Maths.oversample typestable

### DIFF
--- a/src/Maths.jl
+++ b/src/Maths.jl
@@ -472,8 +472,6 @@ end
 Oversample (smooth) an array by 0-padding in the frequency domain
 """
 function oversample(t, x::Array{<:Real, N}; factor::Int=4, dim=1) where N
-    dim = 1
-    factor = 4
     if factor == 1
         return t, x
     end


### PR DESCRIPTION
(edited:) Does not actually remove #212

I believe the problem was simply that `Maths.oversample` was not fully type stable due to the use of `zeros` rather than allocating an `Array` explicitly. `zeros` itself is only type stable if the length of the `Tuple` which determines the array size can be inferred, which is not the case in `Maths.oversample` since it needs to convert to an `Array` first and then back again to change the shape. This meant that Julia just gave up on inference and had the `oversample` return type as `Any`. No idea why this causes such a meltdown in the compiler, but I think this is a matter for a Julia issue?