### PR TITLE
Fix findpeaks test in maths

### DIFF
--- a/test/test_maths.jl
+++ b/test/test_maths.jl
@@ -315,7 +315,8 @@ end
     widths = (30e-15, 3e-15, 100e-15, 200e-15)
     powers = (1e3, 1e4, 1e2, 2e3)
     for i in 1:length(positions)
-        field = Fields.GaussField(λ0=800e-9, τfwhm=widths[i], power=powers[i], τ0=positions[i])
+        field = Fields.GaussField(λ0=800e-9, τfwhm=widths[i], power=powers[i],
+                                  ϕ=[2π*i/length(widths), positions[i]])
         Eω .+= field(grid, FT)
     end
     Et = FT \ Eω


### PR DESCRIPTION
Fixes #219 

The reason this started failing: the old way of shifting the input pulse in time:
```julia
function make_Et(p::PulseField, grid::Grid.RealGrid)
    t = grid.t .- p.τ0
    ω0 = PhysData.wlfreq(p.λ0)
    @. sqrt(p.Itshape(t))*cos(ω0*t + p.ϕ)
end
```
shifted the *origin* of the time axis to `τ0`, so with `p.ϕ` zero, this always generates a cosine pulse. Since #197, shifting in time happens through a spectral phase:
```julia
function (p::PulseField)(grid, FT)
    Et = make_Et(p, grid)
    if length(p.ϕ) >= 1
        Et = FT \ prop_taylor!(FT * Et, grid, p.ϕ, p.λ0)
    end
    [...]
```
and φ1 (group delay) only shifts the envelope, not the carrier.

In the `findpeaks` test, this new way of shifting meant that all of the pulses you add together were in phase, so interference was messing with the pulse envelopes. Adding a phase offset like in this PR means the pulses are added "incoherently" and the tests all pass.

I guess we probably want to be able to shift pulses around without affecting their CEP, right? One way of doing that is to set first element of `p.ϕ` to appropriately shift the absolute phase, e.g.
```julia
λ0 = 800e-9
τfwhm = 5e-15
power = 1e9
τ = 15e-15
field = Fields.GaussField(;λ0, τfwhm, power, ϕ=[PhysData.wlfreq(λ0)*τ, τ])
```
The only other way I can see is to add a `τ0` argument back in.