### PR TITLE
TFC: add run argument to prop_capillary

### DIFF
--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -310,6 +310,8 @@ In this case, all keyword arguments except for `λ0` are ignored.
     only in the working memory. If not `nothing`, should be a file path as a `String`,
     and the results are saved in a file at this location.
 - `status_period::Number`: Interval (in seconds) between printed status updates.
+- `run::Bool=true` : If true (default) run the simulation and return a `Luna.Output`
+   object. If false, setup the simulation, and return the prepared arguments for `Luna.run`.
 """
 function prop_capillary(radius, flength, gas, pressure;
                         λlims, trange, envelope=false, thg=nothing, δt=1,
@@ -321,7 +323,7 @@ function prop_capillary(radius, flength, gas, pressure;
                         modes=:HE11, model=:full, loss=true,
                         raman=false, kerr=true, plasma=nothing,
                         saveN=201, filepath=nothing,
-                        status_period=5)
+                        status_period=5, run=true)
 
     pol = needpol(polarisation, pulses) || needpol_modes(modes)
     @info "X+Y polarisation "* (pol ? "required." : "not required.")
@@ -347,8 +349,12 @@ function prop_capillary(radius, flength, gas, pressure;
         λ0, τfwhm, τw, ϕ, power, energy, pulseshape, polarisation, propagator, pulses, 
         shotnoise, modes, model, loss, raman, kerr, plasma, saveN, filepath)
 
-    Luna.run(Eω, grid, linop, transform, FT, output; status_period)
-    output
+    if run
+        Luna.run(Eω, grid, linop, transform, FT, output; status_period)
+        return output
+    else
+        return Eω, grid, linop, transform, FT, output
+    end
 end
 
 check_orth(mode::Modes.AbstractMode) = nothing

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -310,10 +310,14 @@ In this case, all keyword arguments except for `λ0` are ignored.
     only in the working memory. If not `nothing`, should be a file path as a `String`,
     and the results are saved in a file at this location.
 - `status_period::Number`: Interval (in seconds) between printed status updates.
-- `run::Bool=true` : If true (default) run the simulation and return a `Luna.Output`
-   object. If false, setup the simulation, and return the prepared arguments for `Luna.run`.
 """
-function prop_capillary(radius, flength, gas, pressure;
+function prop_capillary(args...; status_period=5, kwargs...)
+    Eω, grid, linop, transform, FT, output = prop_capillary_args(args...; kwargs...)
+    Luna.run(Eω, grid, linop, transform, FT, output; status_period)
+    output
+end
+
+function prop_capillary_args(radius, flength, gas, pressure;
                         λlims, trange, envelope=false, thg=nothing, δt=1,
                         λ0, τfwhm=nothing, τw=nothing, ϕ=Float64[],
                         power=nothing, energy=nothing,
@@ -322,8 +326,7 @@ function prop_capillary(radius, flength, gas, pressure;
                         shotnoise=true,
                         modes=:HE11, model=:full, loss=true,
                         raman=false, kerr=true, plasma=nothing,
-                        saveN=201, filepath=nothing,
-                        status_period=5, run=true)
+                        saveN=201, filepath=nothing)
 
     pol = needpol(polarisation, pulses) || needpol_modes(modes)
     @info "X+Y polarisation "* (pol ? "required." : "not required.")
@@ -349,12 +352,7 @@ function prop_capillary(radius, flength, gas, pressure;
         λ0, τfwhm, τw, ϕ, power, energy, pulseshape, polarisation, propagator, pulses, 
         shotnoise, modes, model, loss, raman, kerr, plasma, saveN, filepath)
 
-    if run
-        Luna.run(Eω, grid, linop, transform, FT, output; status_period)
-        return output
-    else
-        return Eω, grid, linop, transform, FT, output
-    end
+    return Eω, grid, linop, transform, FT, output
 end
 
 check_orth(mode::Modes.AbstractMode) = nothing


### PR DESCRIPTION
This PR is simply to frame debate. I'm finding the simplified interface so useful that I'd like to use it all the time. However, in the case I need to re-run many simulations (e.g. oscillators) it has too much overhead to recreate everything for each simulation. This PR adds a simple `run` argument to `prop_capillary`, which defaults to `true` and maintains current behaviour. If `false` it instead returns the objects required to pass to `Luna.run` subsequently, so that I can rerun simulations with varying initial conditions. I also had a separate branch, which was more invasive, which created a full `LunaSim` object to hold teh arguments to `Luna.run` and some additional optimisations (e.g. stepfunction isn't recompiled each time etc.), and `Luna.run` then became a method based on that object. But i think that is unnecessary. The overhead of `Luna.run` is currently around 1 s which is OKish. And certainly that approach isn't a quick solution as it reauires more design thought.