### PR TITLE
Fix full modal nonlinear polarisation

### DIFF
--- a/src/Capillary.jl
+++ b/src/Capillary.jl
@@ -261,15 +261,16 @@ dimlimits(m::MarcatiliMode; z=0) = (:polar, (0.0, 0.0), (radius(m, z), 2π))
 
 # we use polar coords, so xs = (r, θ)
 function field(m::MarcatiliMode, xs; z=0)
+    r, θ = xs
     if m.kind == :HE
-        return (besselj(m.n-1, xs[1]*m.unm/radius(m, z)) .* SVector(
-            cos(xs[2])*sin(m.n*(xs[2] + m.ϕ)) - sin(xs[2])*cos(m.n*(xs[2] + m.ϕ)),
-            sin(xs[2])*sin(m.n*(xs[2] + m.ϕ)) + cos(xs[2])*cos(m.n*(xs[2] + m.ϕ))
+        return (besselj(m.n-1, r*m.unm/radius(m, z)) .* SVector(
+            cos(θ)*sin(m.n*(θ + m.ϕ)) - sin(θ)*cos(m.n*(θ + m.ϕ)),
+            sin(θ)*sin(m.n*(θ + m.ϕ)) + cos(θ)*cos(m.n*(θ + m.ϕ))
             ))
     elseif m.kind == :TE
-        return besselj(1, xs[1]*m.unm/radius(m, z)) .* SVector(-sin(xs[2]), cos(xs[2]))
+        return besselj(1, r*m.unm/radius(m, z)) .* SVector(-sin(θ), cos(θ))
     elseif m.kind == :TM
-        return besselj(1, xs[1]*m.unm/radius(m, z)) .* SVector(cos(xs[2]), sin(xs[2]))
+        return besselj(1, r*m.unm/radius(m, z)) .* SVector(cos(θ), sin(θ))
     end
 end
 

--- a/src/Capillary.jl
+++ b/src/Capillary.jl
@@ -7,7 +7,7 @@ using Reexport
 @reexport using Luna.Modes
 import Luna: Maths, Grid
 import Luna.PhysData: c, ε_0, μ_0, ref_index_fun, roomtemp, densityspline, sellmeier_gas
-import Luna.Modes: AbstractMode, dimlimits, neff, field, Aeff, N
+import Luna.Modes: AbstractMode, dimlimits, neff, field, Aeff, N, geomfac
 import Luna.LinearOps: make_linop, conj_clamp, neff_grid, neff_β_grid
 import Luna.PhysData: wlfreq
 import Luna.Utils: subscript
@@ -257,7 +257,9 @@ end
 radius(m::MarcatiliMode{<:Number, Tco, Tcl, LT}, z) where {Tcl, Tco, LT} = m.a
 radius(m::MarcatiliMode, z) = m.a(z)
 
-dimlimits(m::MarcatiliMode; z=0) = (:polar, (0.0, 0.0), (radius(m, z), 2π))
+dimlimits(m::MarcatiliMode; z=0) = (:polar, (0.0, 0.0), (radius(m, z), π))
+
+geomfac(m::MarcatiliMode) = 2
 
 # we use polar coords, so xs = (r, θ)
 function field(m::MarcatiliMode, xs; z=0)

--- a/src/Modes.jl
+++ b/src/Modes.jl
@@ -31,6 +31,8 @@ Maximum dimensional limits of validity for mode `m` at position `z`.
 """
 function dimlimits end
 
+geomfac(m::AbstractMode) = 1
+
 """
     field(m::AbstractMode, xs; z=0.0)
 

--- a/src/NonlinearRHS.jl
+++ b/src/NonlinearRHS.jl
@@ -291,6 +291,7 @@ function (t::TransModal)(nl, Eω, z)
             reltol=t.rtol, abstol=t.atol, maxevals=t.mfcn, error_norm=Cubature.L2)
     end
     nl .= reshape(reinterpret(ComplexF64, val), size(nl))
+    nl .*= Modes.geomfac(t.ts.ms[1])
 end
 
 """

--- a/test/test_multimode.jl
+++ b/test/test_multimode.jl
@@ -58,7 +58,9 @@ end
     energyfun, energyfunω = Fields.energyfuncs(grid)
 
     dens0 = PhysData.density(gas, pres)
-    densityfun(z) = dens0
+    densityfun = let dens0=PhysData.density(gas, pres)
+        z -> dens0
+    end
     responses = (Nonlinear.Kerr_field(PhysData.γ3_gas(gas)),)
     linop, βfun!, frame_vel, αfun = LinearOps.make_const_linop(grid, m, λ0)
     inputs = Fields.GaussField(λ0=λ0, τfwhm=τ, energy=1e-6)


### PR DESCRIPTION
This should (I think) fix #246

`dimlimits` for `MarcatiliMode`s are now (0, π) rather than (0, 2π). There is a new function `Modes.geomfac` which takes this into account by multiplying the integral in `TransModal` by 2. For other modes this defaults to 1. With this change, the initial points at which `pcubature` evaluates the integrand are now (0, π/2, π), so it no longer gets stuck. 

I still have to fully convince myself that this is general--so far it produces correct results for both LP11 propagation (new test in `test_polarisation_field.jl` and HE11 propagation (`test_multimode.jl`).

As it stands this will mess up derived modes, like for example a `ZeisbergerMode`, because they don't implement `geomfac`. So the brute-force method of calculating `Modes.N` and `Modes.Aeff` no longer produces correct results.

TODO:

- [ ] More comprehensive tests
- [ ] Move multiplication by `geomfac` into the loop in `TransModal` to avoid the extra array multiplication
- [ ] Think about a better way of working out the multiplication factor to keep `dimlimits` the same 