### PR TITLE
fix single-output scanproc

### DIFF
--- a/src/Processing.jl
+++ b/src/Processing.jl
@@ -89,7 +89,7 @@ wraptuple(x) = (x,)
 unwraptuple(x::Tuple{<:Any}) = x[1] # single-element Tuple
 unwraptuple(x) = x
 
-function _addret!(array, aidcs, ri::Number)
+function _addret!(array, aidcs, ri)
     array[aidcs] = ri
 end
 
@@ -114,7 +114,7 @@ function scanproc(f, directory::AbstractString=pwd(), pattern::AbstractString=de
 end
 
 # Make array(s) with correct size to hold processing results
-_arrays(ret::Number, shape) = zeros(typeof(ret), shape)
+_arrays(ret, shape) = Array{typeof(ret)}(undef, shape)
 _arrays(ret::AbstractArray, shape) = zeros(eltype(ret), (size(ret)..., shape...))
 _arrays(ret::Tuple, shape) = Tuple([_arrays(ri, shape) for ri in ret])
 _arrays(com::Common, shape) = com.data

--- a/test/test_processing.jl
+++ b/test/test_processing.jl
@@ -259,6 +259,19 @@ end
         end
         @test size(energy_in) == (length(energies), length(pressures))
         @test all(isapprox.(energy_in[:, 1], energies, rtol=1e-4))
+
+        # single-array-output scanproc
+        Iλ2 = Processing.scanproc(td) do output
+            local _, Iλ = Processing.getIω(output, :λ, flength)
+            Iλ[:, 1]
+        end
+        @test Iλ == Iλ2
+
+        #string output scanproc
+        strings = Processing.scanproc(td) do output
+            "a string"
+        end
+        @test size(strings) == (length(energies), length(pressures))
     end
 end
 


### PR DESCRIPTION
Currently `Processing.scanproc` only works if the function it is given returns more than one thing (i.e. a `Tuple`), otherwise it gets confused about what it needs to index into. This fixes that by wrapping a single function output in a `Tuple` and then unwrapping it at the end if necessary.

cc @thanos23 