### PR TITLE
Update README to exclude Julia v1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ There are two ways of using Luna:
 For a short introduction on how to use the simple interface, see the [Quickstart](#quickstart) section below. More information, including on the internals of Luna, can be found in the [Documentation](http://lupo-lab.com/Luna.jl).
 
 ## Installation
-Luna currently only runs with Julia v1.5 or v1.7, which can be obtained from [here](https://julialang.org/downloads/oldreleases/) and [here](https://julialang.org/downloads/#upcoming_release) respectively. Earlier versions lack some required features, and Julia v1.6 triggers an [unresolved bug](https://github.com/LupoLab/Luna/issues/212).
+Luna currently only runs with Julia v1.7, which can be obtained from [here](https://julialang.org/downloads/#upcoming_release). Earlier versions lack some required features, and Julia v1.6 triggers an [unresolved bug](https://github.com/LupoLab/Luna/issues/212).
 
 Once Julia is installed, open a new Julia terminal, and install the [CoolProp](https://github.com//CoolProp/CoolProp.jl) Julia package, then Luna:
 


### PR DESCRIPTION
For whatever reason, probably a minor package upgrade somewhere, Luna no longer runs on Julia v1.5. I don't have time to hunt the culprit, so for now we should just tell people to use v1.7