### PR TITLE
Vincetti model for HC-PCF

### DIFF
--- a/src/Antiresonant.jl
+++ b/src/Antiresonant.jl
@@ -159,15 +159,17 @@ for fun in (:Aeff, :field, :N, :dimlimits)
     @eval ($fun)(m::VincettiMode, args...; kwargs...) = ($fun)(m.m, args...; kwargs...)
 end
 
-function CL(m::VincettiMode, ω; z=0)
+function CL(λ, Rco, t, r_ext, N; cladn=1.45, Nterms=8)
     # eq. (6) of [2]
     # confinement loss in dB/m
-    λ = wlfreq(ω)
-    F = normfreq(λ, m.t, m.cladn)
-    pvs = p_ν_sum(F, m.t, m.r_ext, m.cladn, m.Nterms)
-    clm = CLmin(m.m.a, λ, m.t, m.r_ext, m.cladn)
-    return clm*pvs 
+    F = normfreq(λ, t, cladn)
+    pvs = p_ν_sum(F, t, r_ext, cladn, Nterms)
+    clm = CLmin(Rco, λ, t, r_ext, cladn)
+    return clm*pvs
 end
+
+CL(m::VincettiMode, ω; z=0) = CL(wlfreq(ω), m.m.a, m.t, m.r_ext, m.Ntubes;
+                                 cladn=m.cladn, Nterms=m.Nterms)
 
 function FcHE(μ::Integer, ν::Integer, t, r_ext, n=1.45)
     # eq. (4) in [2]

--- a/src/Antiresonant.jl
+++ b/src/Antiresonant.jl
@@ -164,7 +164,8 @@ function CLmin(Rco, λ, t, r_ext, n)
     3e-4 * λ^4.5/Rco^4 * (1-t/r_ext)^-12 * sqrt(n^2-1)/(t*sqrt(r_ext)) * exp(2λ/(r_ext*(n^2-1)))
 end
 
-L(F) = 0.003^2/(0.003^2 + F^2) # eq. (2) of [2]
+γloss = 3e-3
+L(F) = γloss^2/(γloss^2 + F^2) # eq. (2) of [2]
 
 A(μ) = 2e3 * exp(-0.05*abs(μ-1)^2.6) # eq. (3) of [2]
 
@@ -204,7 +205,8 @@ Rco_eff(m::VincettiMode, ω) = Rco_eff(wlfreq(ω), m.m.a, m.t, m.r_ext, m.Ntubes
 
 getδ(Rco, r_ext, N) = 2*(sin(π/N)*(Rco + r_ext) - r_ext) # from eq. (1) in [1]
 
-Li(F, F_0) = (F_0^2 - F^2)/((F^2 - F_0^2)^2 + (3e-3F)^2) # eq. (2) in [3]
+γdisp = 3e-2
+Li(F, F_0) = (F_0^2 - F^2)/((F^2 - F_0^2)^2 + (γdisp*F)^2) # eq. (2) in [3]
 
 function νsum(F, t, r_ext, n=1.45, Nterms=8)
     # eq. (6) of [3]
@@ -227,6 +229,7 @@ end
 Δneff(m::VincettiMode, ω) = Δneff(wlfreq(ω), m.m.a, m.t, m.r_ext, m.cladn, m.Nterms)
 
 function neff_real(m::VincettiMode, ω; z=0)
+    # eq. (21) of [3]
     ng = m.m.coren(ω; z) # gas index
     return (ng
             - 1/2 * (m.m.unm*c/(ω*ng*Rco_eff(m, ω)))^2

--- a/src/Antiresonant.jl
+++ b/src/Antiresonant.jl
@@ -257,6 +257,15 @@ function getRco(r_ext, N, δ)
     return Rco
 end
 
+"""
+    getr_ext(Rco, N, δ)
+
+Calculate the external radius of the resonators for a single-ring antiresonant PCF with
+core radius `Rco`, `N` resonators and a gap between resonators of `δ`.
+"""
+getr_ext(Rco, N, δ) = (δ/2 - Rco*sin(π/N))/(sin(π/N) - 1)
+
+
 γdisp = 3e-2
 Li(F, F_0) = (F_0^2 - F^2)/((F^2 - F_0^2)^2 + (γdisp*F)^2) # eq. (2) in [3]
 

--- a/src/Antiresonant.jl
+++ b/src/Antiresonant.jl
@@ -104,10 +104,10 @@ struct VincettiMode{mT<:Capillary.MarcatiliMode, LT} <: AbstractMode
 end
 
 """
-    VincettiMode(args...; wallthickness, tube_radius, Ntubes, cladn, Nterms,
-                          loss=true, kwargs...)
+    VincettiMode(a, args...; wallthickness, tube_radius, Ntubes, cladn, Nterms,
+                             loss=true, kwargs...)
 
-Create a mode with Marcatili-like spatial properties but loss and dispersion given
+Create a mode with Marcatili-like mode fields but loss, dispersion and effective area given
 by the semi-empirical model developed by Vincetti et al. in refs [1-3]. Arguments are identical
 to `Capillary.MarcatiliMode` but with the following additions/changes as keyword arguments:
 
@@ -139,7 +139,7 @@ Analytical Formulas for Dispersion and Effective Area in Hollow-Core Tube Lattic
 Fibers, vol. 9, no. 10, Art. no. 10, Oct. 2021, doi: 10.3390/fib9100058.
 """
 function VincettiMode(Rco, args...; wallthickness, tube_radius, Ntubes,
-                               cladn=1.45, Nterms=8, loss=true, kwargs...)
+                                    cladn=1.45, Nterms=8, loss=true, kwargs...)
     if getδ(Rco, tube_radius, Ntubes) < 0
         @warn("the given fibre parameters correspond to a negative gap between resonators")
     end

--- a/src/Antiresonant.jl
+++ b/src/Antiresonant.jl
@@ -155,7 +155,7 @@ neff(m::VincettiMode, ω; z=0) = neff_real(m, ω) + 1im*c/ω*α(m, ω; z)
 α(m::VincettiMode{mT, <:Number}, ω; z=0) where mT = m.loss * log(10)/10 * CL(m, ω; z)
 
 # All other mode properties are identical to a MarcatiliMode
-for fun in (:Aeff, :field, :N, :dimlimits)
+for fun in (:field, :N, :dimlimits)
     @eval ($fun)(m::VincettiMode, args...; kwargs...) = ($fun)(m.m, args...; kwargs...)
 end
 
@@ -287,5 +287,7 @@ function neff_real(m::VincettiMode, ω; z=0)
             - 1/2 * (m.m.unm*c/(ω*ng*Rco_eff(m, ω)))^2
             + Δneff(m, ω))
 end
+
+Aeff(m::VincettiMode, ω; z=0) = 0.48/8π * (m.m.unm*wlfreq(ω))^2/(m.m.coren(ω; z)-neff_real(m, ω))
 
 end # module

--- a/src/Antiresonant.jl
+++ b/src/Antiresonant.jl
@@ -122,7 +122,8 @@ to `Capillary.MarcatiliMode` but with the following additions/changes as keyword
 - `Nterms` : number of resonator dielectric modes to include in the model. Defaults to 8.
 - `loss` : can be `true` or `false` to switch loss on/off, or a `Real` to scale the loss.
 
-To specify the gap between resonators, calculate the core radius with [`getRco(r_ext, N, δ)`](@ref).
+To specify the gap between resonators, calculate the core radius with [`getRco(r_ext, N, δ)`](@ref)
+or calculate the external radius of the resonators with [`getr_ext(Rco, N, δ)`](@ref).
 
 # References
 

--- a/test/test_antiresonant.jl
+++ b/test/test_antiresonant.jl
@@ -50,9 +50,11 @@ N = 8 # number of tubes
 k = 1 + δ/2r_ext
 Rco = r_ext * (k/sin(π/N) - 1)
 
-m = Antiresonant.VincettiMode(Rco; wallthickness=t, tube_radius=r_ext, cladn=n)
+δcalc = 2*(sin(π/N)*(Rco + r_ext)-r_ext)
 
-F = collect(range(0.4, 4.2, 1024))
+m = Antiresonant.VincettiMode(Rco; wallthickness=t, tube_radius=r_ext, Ntubes=N, cladn=n)
+
+F = collect(range(0.4, 4.2, 2^14))
 λ = @. 2t/F*sqrt(n^2-1)
 
 paperdata = readdlm(joinpath(
@@ -80,3 +82,9 @@ plt.xlim(extrema(λ).*1e9)
 plt.xlabel("Wavelength (nm)")
 plt.ylabel("Loss (dB/m)")
 plt.legend()
+
+##
+plt.figure()
+plt.plot(F, Antiresonant.neff_real.(m, PhysData.wlfreq.(λ)))
+plt.ylim(0.998, 1)
+plt.xlim(xmax=4)

--- a/test/test_antiresonant.jl
+++ b/test/test_antiresonant.jl
@@ -27,3 +27,56 @@ import Luna.PhysData: wlfreq
     @test_throws ArgumentError Antiresonant.ZeisbergerMode(a, :Air, 0; wallthickness=w, loss=0.5im)
 end
 
+##
+#= References
+[1] L. Vincetti
+Empirical formulas for calculating loss in hollow core tube lattice fibers, 
+Opt. Express, OE, vol. 24, no. 10, pp. 10313-10325, May 2016, doi: 10.1364/OE.24.010313.
+
+[2] L. Vincetti and L. Rosa
+A simple analytical model for confinement loss estimation in hollow-core Tube Lattice Fibers
+Opt. Express, OE, vol. 27, no. 4, pp. 5230-5237, Feb. 2019, doi: 10.1364/OE.27.005230.
+=#
+# F#1 from [2]
+import PyPlot: plt
+import DelimitedFiles: readdlm
+t = 1e-6
+r_ext = 10e-6
+δ = 5e-6 # tube spacing
+n = 1.44
+N = 8 # number of tubes
+
+# eq. (1) of [1]
+k = 1 + δ/2r_ext
+Rco = r_ext * (k/sin(π/N) - 1)
+
+m = Antiresonant.VincettiMode(Rco; wallthickness=t, tube_radius=r_ext, cladn=n)
+
+F = collect(range(0.4, 4.2, 1024))
+λ = @. 2t/F*sqrt(n^2-1)
+
+paperdata = readdlm(joinpath(
+    homedir(),
+    "Documents",
+    "WebPlotDigitizer",
+    "Vincetti PCF loss",
+    "VincettiLoss_F#1.csv"),
+    ',')
+
+##
+plt.figure()
+plt.semilogy(F, Modes.dB_per_m.(m, PhysData.wlfreq.(λ)); label="Luna")
+plt.semilogy(paperdata[:, 1], paperdata[:, 2], "."; label="Paper")
+plt.xlim(extrema(F))
+plt.xlabel("Normalised frequency")
+plt.ylabel("Loss (dB/m)")
+plt.legend()
+
+λpaper = @. 2t/paperdata[:, 1]*sqrt(n^2-1)
+plt.figure()
+plt.semilogy(λ*1e9, Modes.dB_per_m.(m, PhysData.wlfreq.(λ)); label="Luna")
+plt.semilogy(λpaper*1e9, paperdata[:, 2], "."; label="Paper")
+plt.xlim(extrema(λ).*1e9)
+plt.xlabel("Wavelength (nm)")
+plt.ylabel("Loss (dB/m)")
+plt.legend()

--- a/test/test_antiresonant.jl
+++ b/test/test_antiresonant.jl
@@ -53,6 +53,7 @@ Rco = r_ext * (k/sin(π/N) - 1)
 δcalc = 2*(sin(π/N)*(Rco + r_ext)-r_ext)
 
 m = Antiresonant.VincettiMode(Rco; wallthickness=t, tube_radius=r_ext, Ntubes=N, cladn=n)
+zm = Antiresonant.ZeisbergerMode(Rco, :Air, 0, (ω; z) -> 1.45; wallthickness=t)
 
 F = collect(range(0.4, 4.2, 2^14))
 λ = @. 2t/F*sqrt(n^2-1)
@@ -67,7 +68,8 @@ paperdata = readdlm(joinpath(
 
 ##
 plt.figure()
-plt.semilogy(F, Modes.dB_per_m.(m, PhysData.wlfreq.(λ)); label="Luna")
+plt.semilogy(F, Modes.dB_per_m.(m, PhysData.wlfreq.(λ)); label="Luna (Vincetti)")
+plt.semilogy(F, Modes.dB_per_m.(zm, PhysData.wlfreq.(λ)); label="Luna (Zeisberger)")
 plt.semilogy(paperdata[:, 1], paperdata[:, 2], "."; label="Paper")
 plt.xlim(extrema(F))
 plt.xlabel("Normalised frequency")
@@ -77,6 +79,7 @@ plt.legend()
 λpaper = @. 2t/paperdata[:, 1]*sqrt(n^2-1)
 plt.figure()
 plt.semilogy(λ*1e9, Modes.dB_per_m.(m, PhysData.wlfreq.(λ)); label="Luna")
+plt.semilogy(λ*1e9, Modes.dB_per_m.(zm, PhysData.wlfreq.(λ)); label="Luna (Zeisberger)")
 plt.semilogy(λpaper*1e9, paperdata[:, 2], "."; label="Paper")
 plt.xlim(extrema(λ).*1e9)
 plt.xlabel("Wavelength (nm)")
@@ -84,7 +87,22 @@ plt.ylabel("Loss (dB/m)")
 plt.legend()
 
 ##
+neffdata = readdlm(joinpath(
+    homedir(),
+    "Documents",
+    "WebPlotDigitizer",
+    "Vincetti PCF loss",
+    "neff_F#1.csv"),
+    ',')
+
 plt.figure()
-plt.plot(F, Antiresonant.neff_real.(m, PhysData.wlfreq.(λ)))
-plt.ylim(0.998, 1)
-plt.xlim(xmax=4)
+plt.plot(F, Antiresonant.neff_real.(m, PhysData.wlfreq.(λ)); label="Luna (Vincetti)")
+plt.plot(F, real(Antiresonant.neff.(zm, PhysData.wlfreq.(λ))); label="Luna (Zeisberger)")
+plt.plot(F, real(Antiresonant.neff.(m.m, PhysData.wlfreq.(λ))); label="Luna (Marcatili)")
+plt.plot(neffdata[:, 1], neffdata[:, 2], "--"; label="Paper")
+plt.ylim(0.999, 1)
+plt.xlim(extrema(F))
+plt.xlabel("Normalised frequency")
+plt.ylabel("\$n_\\mathrm{eff}\$")
+plt.legend()
+plt.tight_layout()

--- a/test/test_antiresonant.jl
+++ b/test/test_antiresonant.jl
@@ -38,6 +38,7 @@ A simple analytical model for confinement loss estimation in hollow-core Tube La
 Opt. Express, OE, vol. 27, no. 4, pp. 5230-5237, Feb. 2019, doi: 10.1364/OE.27.005230.
 =#
 # F#1 from [2]
+using Luna
 import PyPlot: plt
 import DelimitedFiles: readdlm
 t = 1e-6
@@ -57,6 +58,11 @@ zm = Antiresonant.ZeisbergerMode(Rco, :Air, 0, (ω; z) -> 1.45; wallthickness=t)
 
 F = collect(range(0.4, 4.2, 2^14))
 λ = @. 2t/F*sqrt(n^2-1)
+
+scale = 0.5
+msc = Antiresonant.VincettiMode(Rco; wallthickness=t, tube_radius=r_ext, Ntubes=N, cladn=n,
+                                     loss=scale)
+@test Modes.α.(msc, PhysData.wlfreq.(λ)) ≈ scale*Modes.α.(m, PhysData.wlfreq.(λ))
 
 paperdata = readdlm(joinpath(
     homedir(),

--- a/test/test_antiresonant.jl
+++ b/test/test_antiresonant.jl
@@ -112,3 +112,20 @@ plt.xlabel("Normalised frequency")
 plt.ylabel("\$n_\\mathrm{eff}\$")
 plt.legend()
 plt.tight_layout()
+
+##
+β2v = Modes.dispersion.(m, 2, PhysData.wlfreq.(λ))
+β2z = Modes.dispersion.(zm, 2, PhysData.wlfreq.(λ))
+β2m = Modes.dispersion.(m.m, 2, PhysData.wlfreq.(λ))
+
+##
+plt.figure()
+plt.plot(λ*1e9, 1e28β2v; label="Luna (Vincetti)")
+plt.plot(λ*1e9, 1e28β2z; label="Luna (Zeisberger)")
+plt.plot(λ*1e9, 1e28β2m; label="Luna (Marcatili)")
+plt.ylim(-200, 100)
+plt.xlim(500, 2500)
+plt.xlabel("Wavelength (nm)")
+plt.ylabel("GVD (fs\$^{-2}\$/cm)")
+plt.legend()
+plt.tight_layout()


### PR DESCRIPTION
As the title says.

Comparison with some data digitised from the papers (this is what they call fibre 1)

![image](https://user-images.githubusercontent.com/38351086/158649117-be80d6b4-9b03-49a2-848a-be7163901ceb.png)
![image](https://user-images.githubusercontent.com/38351086/158649270-dfc8e168-a4f4-4f74-9793-6610f17dacde.png)

One issue is that there is an inconsistency in the dispersion part. In eq. (2) of the dispersion paper (https://doi.org/10.3390/fib9100058) the damping constant is given as 3e-3, but I'm using 3e-2 instead. If I use their numbers exactly as written in the paper, I get this:
![image](https://user-images.githubusercontent.com/38351086/158649501-66742e67-6ecd-4983-9723-6eba93b8d1d0.png)

Other TODOs:

- [x] Actual unit tests rather than just some plots
- [ ] Effective area model (this is frequency dependent so will have to interact with #265)

cc @SabbahMohammed 