### PR TITLE
Fix step size regulation for propagation without nonlinearity

### DIFF
--- a/src/RK45.jl
+++ b/src/RK45.jl
@@ -373,7 +373,7 @@ function stepcontrolPI!(s)
     ε = 0.8
     if s.ok
         s.errlast == 0 && (s.errlast = s.err) # if last error is zero, use current error instead
-        if s.errlast == 0 || s.err == 0
+        if s.err == 0
             fac = 1.5 # zero error means no nonlinearity: increase step size by a lot 
         else
             fac = s.safety * (ε/s.err)^β1 * (ε/s.errlast)^β2

--- a/src/RK45.jl
+++ b/src/RK45.jl
@@ -175,6 +175,7 @@ function step!(s)
         errest[ii] == 0 || (@. s.yerr += s.dt*s.ks[ii]*errest[ii])
     end
     s.err = s.norm(s.yerr, s.y, s.yn, s.rtol, s.atol)
+    s.err = max(s.err, 1e-3)
     s.ok = s.err <= 1
     stepcontrolPI!(s)
     if s.ok

--- a/src/RK45.jl
+++ b/src/RK45.jl
@@ -373,7 +373,7 @@ function stepcontrolPI!(s)
     ε = 0.8
     if s.ok
         s.errlast == 0 && (s.errlast = s.err) # if last error is zero, use current error instead
-        if s.errlast == 0 # if last error is *still* zero, both s.errlast and s.err are zero
+        if s.errlast == 0 || s.err == 0
             fac = 1.5 # zero error means no nonlinearity: increase step size by a lot 
         else
             fac = s.safety * (ε/s.err)^β1 * (ε/s.errlast)^β2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -147,5 +147,10 @@ end
     include(joinpath(testdir, "test_interface.jl"))
 end
 
+@testset "Linear propagation" begin
+    @info("================= test_linearprop.jl")
+    include(joinpath(testdir, "test_linearprop.jl"))
+end
+
 
 end

--- a/test/test_linearprop.jl
+++ b/test/test_linearprop.jl
@@ -13,10 +13,10 @@ energy = 60e-6 # energy in the pump pulse
 
 τ0 = Tools.τfw_to_τ0(τfwhm, :gauss)
 
-duv = prop_capillary(radius, flength, gas, pressure; λ0, τfwhm, energy,
-                     modes=:HE11, trange=400e-15, λlims=(150e-9, 4e-6), kerr=false, plasma=false)
+out = prop_capillary(radius, flength, gas, pressure; λ0, τfwhm, energy,
+                     modes=:HE11, trange=1000e-15, λlims=(150e-9, 4e-6), kerr=false, plasma=false)
 
-t, Et = Processing.getEt(duv)
+t, Et = Processing.getEt(out)
 Ptend = abs2.(Et[:, end]) # pulse profile at end
 
 fwend = Maths.fwhm(t, Ptend; method=:spline) # FWHM duration at end
@@ -30,6 +30,6 @@ GDD = β2*flength # total GDD accumulated
 
 @test isapprox(τ0calc, τ0end; rtol=1e-2)
 
-energy_calc = Capillary.transmission(radius, λ0, flength)*energy
-@test isapprox(energy_calc, Processing.energy(duv)[end]; rtol=1e-2)
+energy_calc = Capillary.transmission(radius, λ0, flength)*energy # calculated energy at end
+@test isapprox(energy_calc, Processing.energy(out)[end]; rtol=1e-2)
 

--- a/test/test_linearprop.jl
+++ b/test/test_linearprop.jl
@@ -1,0 +1,35 @@
+using Luna
+import Test: @test, @testset
+
+radius = 125e-6 # HCF core radius
+flength = 3 # HCF length
+
+gas = :Ar
+pressure = 80e-3 # gas pressure in bar
+
+λ0 = 800e-9 # central wavelength of the pump pulse
+τfwhm = 10e-15 # FWHM duration of the pump pulse
+energy = 60e-6 # energy in the pump pulse
+
+τ0 = Tools.τfw_to_τ0(τfwhm, :gauss)
+
+duv = prop_capillary(radius, flength, gas, pressure; λ0, τfwhm, energy,
+                     modes=:HE11, trange=400e-15, λlims=(150e-9, 4e-6), kerr=false, plasma=false)
+
+t, Et = Processing.getEt(duv)
+Ptend = abs2.(Et[:, end]) # pulse profile at end
+
+fwend = Maths.fwhm(t, Ptend; method=:spline) # FWHM duration at end
+τ0end = Tools.τfw_to_τ0(fwend, :gauss) # Gaussian τ0 duration at end
+
+mode = Capillary.MarcatiliMode(radius, gas, pressure) # propagation mode
+β2 = Modes.dispersion(mode, 2, PhysData.wlfreq(λ0)) # dispersion of the mode
+GDD = β2*flength # total GDD accumulated
+
+τ0calc = sqrt((GDD/τ0)^2 + τ0^2) # analytical formula for Gaussian duration after GDD
+
+@test isapprox(τ0calc, τ0end; rtol=1e-2)
+
+energy_calc = Capillary.transmission(radius, λ0, flength)*energy
+@test isapprox(energy_calc, Processing.energy(duv)[end]; rtol=1e-2)
+


### PR DESCRIPTION
This makes the step size controller in `RK45.jl` deal with a zero-valued error more gracefully (by increasing the step size by some fixed large amount), instead of throwing out `NaN`s and breaking the propagation.

Without this change, the following code errors:
```julia
using Luna

a = 75e-6
flength = 0.55
gas = :He
pressure = 10

λ0 = 1030e-9
τfwhm = 10e-15
energy = 45e-6

λlims = (160e-9, 4e-6)
trange = 0.5e-12

duv = prop_capillary(a, flength, gas, pressure; λ0, τfwhm, energy, λlims, trange,
                     plasma=false, kerr=false, status_period=0)
```

Fixes #270 