### PR TITLE
Fix plot label creation for rect modes

### DIFF
--- a/src/Plotting.jl
+++ b/src/Plotting.jl
@@ -90,7 +90,12 @@ function get_modes(output)
     endline = findnext(li -> !startswith(li, " "^4), lines, modeline+1)
     mlines = lines[modeline+1 : endline-1]
     labels = [match(r"{([^,]*),", li).captures[1] for li in mlines]
-    angles = parse.(Float64, [match(r"ϕ=([0-9]+.[0-9]+)π", li).captures[1] for li in mlines])
+    angles = zeros(length(mlines))
+    for (ii, li) in enumerate(mlines)
+        m = match(r"ϕ=([0-9]+.[0-9]+)π", li)
+        isnothing(m) && continue # no angle information in mode label)
+        angles[ii] = parse(Float64, m.captures[1])
+    end
     if !all(angles .== 0)
         for i in eachindex(labels)
             if startswith(labels[i], "HE")

--- a/src/RectModes.jl
+++ b/src/RectModes.jl
@@ -5,6 +5,7 @@ using Reexport
 import Luna: Maths
 import Luna.PhysData: c, ε_0, μ_0, ref_index_fun, roomtemp
 import Luna.Modes: AbstractMode, dimlimits, neff, field, Aeff, N
+import Base: show
 
 export RectMode, dimlimits, neff, field, N, Aeff
 


### PR DESCRIPTION
As the title says, this fixes the label creation for rectangular modes to enable functions like `Plotting.stats` and other things which use the labels. 