### PR TITLE
Simple interface: defaults for envelope and correct logging

### DIFF
--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -509,9 +509,9 @@ function makeresponse(grid::Grid.RealGrid, gas, raman, kerr, plasma, thg, pol,
     makeplasma!(out, grid, gas, plasma, pol)
     if isnothing(raman)
         raman = gas in (:N2, :H2, :D2, :N2O, :CH4, :SF6)
-        raman && @info("Including the Raman response (due to molecular gas choice).")
     end
     if raman
+        @info("Including the Raman response (due to molecular gas choice).")
         rr = Raman.raman_response(grid.to, gas, rotation=rotation, vibration=vibration)
         if thg
             push!(out, Nonlinear.RamanPolarField(grid.to, rr))
@@ -564,7 +564,11 @@ function makeresponse(grid::Grid.EnvGrid, gas, raman, kerr, plasma, thg, pol,
             push!(out, Nonlinear.Kerr_env(PhysData.γ3_gas(gas)))
         end
     end
+    if isnothing(raman)
+        raman = gas in (:N2, :H2, :D2, :N2O, :CH4, :SF6)
+    end
     if raman
+        @info("Including the Raman response (due to molecular gas choice).")
         rr = Raman.raman_response(grid.to, gas, rotation=rotation, vibration=vibration)
         push!(out, Nonlinear.RamanPolarEnv(grid.to, rr))
     end

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -523,15 +523,18 @@ function makeresponse(grid::Grid.RealGrid, gas, raman, kerr, plasma, thg, pol,
 end
 
 function makeplasma!(out, grid, gas, plasma::Bool, pol)
-    # simple true/false => default to PPT
-    model = :PPT
+    # simple true/false => default to PPT for atoms, ADK for molecules
+    if ~plasma
+        return
+    end
     if gas in (:H2, :D2, :N2O, :CH4, :SF6)
         @info("Using ADK ionisation rate (due to molecular gas choice).")
         model = :ADK
     else
         @info("Using PPT ionisation rate.")
+        model = :PPT
     end
-    plasma && makeplasma!(out, grid, gas, model, pol)
+    makeplasma!(out, grid, gas, model, pol)
 end
 
 function makeplasma!(out, grid, gas, plasma::Symbol, pol)

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -509,7 +509,7 @@ function makeresponse(grid::Grid.RealGrid, gas, raman, kerr, plasma, thg, pol,
     makeplasma!(out, grid, gas, plasma, pol)
     if isnothing(raman)
         raman = gas in (:N2, :H2, :D2, :N2O, :CH4, :SF6)
-        @info("Including the Raman response (due to molecular gas choice).")
+        raman && @info("Including the Raman response (due to molecular gas choice).")
     end
     if raman
         rr = Raman.raman_response(grid.to, gas, rotation=rotation, vibration=vibration)

--- a/test/test_interface.jl
+++ b/test/test_interface.jl
@@ -191,17 +191,19 @@ end
 
 ##
 @testset "Defaults" begin
-@testset "Defaults for $gas" for gas in PhysData.gas
-    # Check that prop_capillary has working defaults for all gases
-    gas == :Air && continue
-    a = 100e-6
-    flength = 0.1
-    pressure = 1
-    kwargs = (λ0=800e-9, energy=1e-12, τfwhm=10e-15, shotnoise=false, trange=250e-15,
-              λlims=(200e-9, 4e-6), saveN=51)
-    prop_capillary(a, flength, gas, pressure; kwargs...)
-    @test true
-end
+    @testset "Envelope propagation: $env" for env in [false, true]
+        @testset "Defaults for $gas" for gas in PhysData.gas
+            # Check that prop_capillary has working defaults for all gases
+            gas == :Air && continue
+            a = 100e-6
+            flength = 0.1
+            pressure = 1
+            kwargs = (λ0=800e-9, energy=1e-12, τfwhm=10e-15, shotnoise=false, trange=250e-15,
+                      λlims=(200e-9, 4e-6), saveN=51, envelope=env)
+            prop_capillary(a, flength, gas, pressure; kwargs...)
+            @test true
+        end
+    end
 end
 
 ##


### PR DESCRIPTION
 - Only show log message about Raman being included when it's actually included
 - Only show log message about PPT rate when plasma is on
 - Assign atomic/molecular defaults also for envelope propagation