### PR TITLE
transfer all modes in LunaPulse

### DIFF
--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -699,13 +699,12 @@ nmult(x::Nothing, fac) = x
 nmult(x, fac) = x*fac
 
 function ellfields(pulse::Union{Pulses.CustomPulse, Pulses.GaussPulse, Pulses.SechPulse})
-    f = pulse.field.field
-    pf = pulse.field
+    f = pulse.field
     py, px = ellfac(pulse.polarisation)
     f1 = Fields.PulseField(f.λ0, nmult(f.energy, py), nmult(f.power, py), f.ϕ, f.Itshape)
     f2 = Fields.PulseField(f.λ0, nmult(f.energy, px), nmult(f.power, px),
                            ellphase(f.ϕ, pulse.polarisation), f.Itshape)
-    Fields.PropagatedField(pf.propagator!, f1), Fields.PropagatedField(pf.propagator!, f2)
+    f1, f2
 end
 
 function ellfields(pulse::Pulses.DataPulse)

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -415,6 +415,7 @@ function needpol(pol)
 end
 needpol(pol::Number) = true
 needpol(pulse::Pulses.AbstractPulse) = needpol(pulse.polarisation)
+needpol(pulses::Vector{<:Pulses.AbstractPulse}) = any(needpol, pulses)
 
 needpol(pol, pulses::Nothing) = needpol(pol)
 needpol(pol, pulse::Pulses.AbstractPulse) = needpol(pulse)

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -699,21 +699,23 @@ nmult(x::Nothing, fac) = x
 nmult(x, fac) = x*fac
 
 function ellfields(pulse::Union{Pulses.CustomPulse, Pulses.GaussPulse, Pulses.SechPulse})
-    f = pulse.field
+    f = pulse.field.field
+    pf = pulse.field
     py, px = ellfac(pulse.polarisation)
     f1 = Fields.PulseField(f.λ0, nmult(f.energy, py), nmult(f.power, py), f.ϕ, f.Itshape)
     f2 = Fields.PulseField(f.λ0, nmult(f.energy, px), nmult(f.power, px),
                            ellphase(f.ϕ, pulse.polarisation), f.Itshape)
-    f1, f2
+    Fields.PropagatedField(pf.propagator!, f1), Fields.PropagatedField(pf.propagator!, f2)
 end
 
 function ellfields(pulse::Pulses.DataPulse)
-    f = pulse.field
+    f = pulse.field.field
+    pf = pulse.field
     py, px = ellfac(pulse.polarisation)
     f1 = Fields.DataField(f.ω, f.Iω, f.ϕω, nmult(f.energy, py), f.ϕ, f.λ0)
     f2 = Fields.DataField(f.ω, f.Iω, f.ϕω, nmult(f.energy, px),
                           ellphase(f.ϕ, pulse.polarisation), f.λ0)
-    f1, f2
+    Fields.PropagatedField(pf.propagator!, f1), Fields.PropagatedField(pf.propagator!, f2)
 end
 
 function shotnoise_maybe(inputs, mode::Modes.AbstractMode, shotnoise::Bool)

--- a/test/test_interface.jl
+++ b/test/test_interface.jl
@@ -288,6 +288,24 @@ end
     # total energy should be weighted sum from before
     ei2 = Processing.energy(o2)[:, 1]
     @test ei2 ≈ eo1 .* es
+
+    # make sure coupling to fewer modes throws an error
+    kwargs = (λ0=800e-9, τfwhm=10e-15, trange=400e-15, λlims=(150e-9, 4e-6), shotnoise=false, modes=2)
+    p = Pulses.LunaPulse(o1;)
+    @test_throws ErrorException o2 = prop_capillary(args...; pulses=p, kwargs...)
+
+    # make sure coupling to *different* modes throws an error
+    kwargs = (λ0=800e-9, τfwhm=10e-15, trange=400e-15, λlims=(150e-9, 4e-6), shotnoise=false, modes=(:HE21, :HE22, :HE23, :HE24))
+    p = Pulses.LunaPulse(o1;)
+    @test_throws ErrorException o2 = prop_capillary(args...; pulses=p, kwargs...)
+
+    # coupling to more modes should work fine
+    kwargs = (λ0=800e-9, τfwhm=10e-15, trange=400e-15, λlims=(150e-9, 4e-6), shotnoise=false, modes=6)
+    p = Pulses.LunaPulse(o1;)
+    ei2 = Processing.energy(o2)[:, 1]
+    prop_capillary(args...; pulses=p, kwargs...)
+    @test sum(ei2) ≈ sum(eo1)
+    @test all(ei2[5:end] .== 0)
 end
 
 ##


### PR DESCRIPTION
As it says on the tin: instead of just transferring the fundamental mode, make `LunaPulse`s transfer all modes. Only works if the modes in the two simulations are exactly the same. 

Energy in the transferred field can be defined in a few different ways by keyword arguments to `LunaPulse`
1. No arguments given: full energy is transferred from one sim to the next
2. `energy` given: total energy is scaled to this value
3. `scale_energy` given as `Number`: total energy is scaled by this factor
4. `scale_energy` given as `Vector`: energy in each mode is scaled differently

TODO:

- [x] Think about possible edge cases
- [x]  Add tests to check that correct and understandable exceptions are thrown

CC @nkotsina @martgebhardt 