### PR TITLE
Scan processing improvements

### DIFF
--- a/src/Processing.jl
+++ b/src/Processing.jl
@@ -68,14 +68,15 @@ end
 ```
 """
 function scanproc(f, scanfiles::AbstractVector{<:AbstractString}; shape=nothing)
-    local scanidcs, arrays
+    local scanidcs = nothing
+    local arrays = nothing
     scanfiles = sort(scanfiles)
     @progress for (idx, fi) in enumerate(scanfiles)
         try
             o = HDF5Output(fi)
             # wraptuple makes sure we definitely have a Tuple, even if f only returns one thing
             ret = wraptuple(f(o))
-            if idx == 1 # initialise arrays
+            if isnothing(scanidcs) # initialise arrays
                 isnothing(shape) && (shape = Tuple(o["meta"]["scanshape"]))
                 scanidcs = CartesianIndices(shape)
                 arrays = _arrays(ret, shape)
@@ -107,12 +108,13 @@ Values returned by `f` which are guaranteed to be identical for each processed o
 wrapped in a `Common`, and `scanproc` only returns these once.
 """
 function scanproc(f, outputs; shape=nothing)
-    local scanidcs, arrays
+    local scanidcs = nothing
+    local arrays = nothing
     @progress for (idx, o) in enumerate(outputs)
         try
             # wraptuple makes sure we definitely have a Tuple, even if f only returns one thing
             ret = wraptuple(f(o))
-            if idx == 1 # initialise arrays
+            if isnothing(scanidcs) # initialise arrays
                 isnothing(shape) && (shape = Tuple(o["meta"]["scanshape"]))
                 scanidcs = CartesianIndices(shape)
                 arrays = _arrays(ret, shape)

--- a/src/Processing.jl
+++ b/src/Processing.jl
@@ -1035,9 +1035,10 @@ end
     nearest_z(output, z)
 
 Return the index of saved z-position(s) closest to the position(s) `z`. Output is always
-an array, even if `z` is a number.
+an array, even if `z` is a number. If `z` is negative, its absolute value is taken as the fraction
+of the total propagation distance.
 """
-nearest_z(output, z::Number) = z < 0 ? [length(output["z"])] : [argmin(abs.(output["z"] .- z))]
+nearest_z(output, z::Number) = z < 0 ? [round(Int, min(abs(z), 1)*length(output["z"]))] : [argmin(abs.(output["z"] .- z))]
 nearest_z(output, z) = [nearest_z(output, zi)[1] for zi in z]
 
 end

--- a/src/Scans.jl
+++ b/src/Scans.jl
@@ -271,17 +271,19 @@ function runscan(f, scan::Scan{LocalExec})
 end
 
 function runscan(f, scan::Scan{RangeExec})
+    out = Any[]
     combos = vec(collect(Iterators.product(scan.arrays...)))
     for (scanidx, args) in enumerate(combos[scan.exec.r])
         logiter(scan, scanidx, args)
         try
-            f(scanidx, args...)
+            push!(out, f(scanidx, args...))
         catch e
             bt = catch_backtrace()
             msg = "Error at scanidx $scanidx:\n"*sprint(showerror, e, bt)
             @warn msg
         end
     end
+    out
 end
 
 """


### PR DESCRIPTION
Some improvements to scans and their processing:

- For `Processing` functions which accept a `zslice` argument (e.g. to extract the SED at one z position), the `zslice` can now be negative, in which case the number is taken as the *fraction* of the propagation length. E.g. -1 gives the final slice, -0.5 gives halfway through etc.
- `runscan` with a `LocalExec` or `RangeExec` now returns a simple array containing the return values of the function. This can be used to quickly run scans locally.
- Related to the above, there is now a version of `scanproc` which takes an array of `AbstractOutput`s and a scan shape.
- `scanproc` more robustly initialises its output array and can now deal with the edge case where the very first propagation failed to produce output for whatever reason.