### PR TITLE
restrict Capillary.gradient to vectors to avoid confusions

### DIFF
--- a/src/Capillary.jl
+++ b/src/Capillary.jl
@@ -313,7 +313,7 @@ end
 Convenience function to create density and core index profiles for
 multi-point gradient fills defined by positions `Z` and pressures `P`.
 """
-function gradient(gas, Z, P)
+function gradient(gas, Z::AbstractVector, P::AbstractVector)
     γ = sellmeier_gas(gas)
     ex = extrema(P)
     dspl = densityspline(gas, Pmin=ex[1]==ex[2] ? 0 : ex[1], Pmax=ex[2])


### PR DESCRIPTION
this is mainly to fix some issues further down the line with using some processing functions which parse the arguments to `prop_capillary` based on type. needs a better long-term fix but this way at least that throws the correct error. 