### PR TITLE
add scalefield for PropagatedField

### DIFF
--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -655,6 +655,10 @@ function scalefield(f::Fields.DataField, fac)
     Fields.DataField(f.ω, f.Iω, f.ϕω, nmult(f.energy, fac), f.ϕ, f.λ0)
 end
 
+function scalefield(f::Fields.PropagatedField, fac)
+    Fields.PropagatedField(f.propagator!, scalefield(f.field, fac))
+end
+
 _findmode(mode_s, md) = _findmode([mode_s], md)
 
 function makeinputs(mode_s, λ0, pulse::Pulses.AbstractPulse)


### PR DESCRIPTION
@jtravs this should enable you to do a `GaussBeamPulse` with a `DataField` *and* a propagator function all at the same time. Please could you test that with your code? I don't have an example set up right now.