### PR TITLE
Documentation for mode-averaged propagation

### DIFF
--- a/docs/src/model/modal_decompositions.md
+++ b/docs/src/model/modal_decompositions.md
@@ -112,7 +112,7 @@ I_\mathrm{av} = \frac{1}{2}\varepsilon_0 c \vert E_\mathrm{av}\vert^2 = \frac{\v
 Plugging in the definition of ``E_\mathrm{av}``, the UPPE reads
 ```math
 \begin{align*}
-\sqrt{\frac{1}{2}\varepsilon_0 c A_\mathrm{eff}}\partial_z \tilde{E}'(\omega, z) &= i \left(\frac{\omega}{c} n_\mathrm{eff}(\omega, z) - \frac{\omega}{v}\right)\sqrt{\frac{1}{2}\varepsilon_0 c A_\mathrm{eff}}\tilde{E}'(\omega, z)\\[1em]
+\sqrt{\frac{1}{2}\varepsilon_0 c A_\mathrm{eff}}\partial_z \tilde{E}_\mathrm{av}(\omega, z) &= i \left(\frac{\omega}{c} n_\mathrm{eff}(\omega, z) - \frac{\omega}{v}\right)\sqrt{\frac{1}{2}\varepsilon_0 c A_\mathrm{eff}}\tilde{E}_\mathrm{av}(\omega, z)\\[1em]
 &\qquad + i\frac{\omega}{4} C\Big(\frac{1}{2}\varepsilon_0 c A_\mathrm{eff}\Big)^{\frac{3}{2}}\frac{4}{\varepsilon_0^2c^2 A_\mathrm{eff}} \int_{-\infty}^\infty \mathrm{d} t\, E_\mathrm{av}(t, z)^3 \mathrm{e}^{i \omega t}\,.
 \end{align*}
 ```

--- a/docs/src/model/modal_decompositions.md
+++ b/docs/src/model/modal_decompositions.md
@@ -5,11 +5,11 @@
 ## Multi-mode guided
 For propagation in waveguides taking into account multiple modes and the coupling between them, Luna uses the model laid out in [Kolesik and Moloney, *Nonlinear optical pulse propagation simulation: From Maxwell’s to unidirectional equations*](https://journals.aps.org/pre/abstract/10.1103/PhysRevE.70.036604) and [Tani et al., *Multimode ultrafast nonlinear optics in optical waveguides: numerical modeling and experiments in kagomé photonic-crystal fiber*](http://josab.osa.org/abstract.cfm?URI=josab-31-2-311). This is implemented in [`NonlinearRHS.TransModal`](@ref). The electric field ``\mathbf{E}(t, \mathbf{r_\perp}, z)`` is expressed as the inverse Fourier transform in time and the superposition of waveguide modes in space. This means that the transverse wave vector ``\mathbf{k}_\perp`` turns into a modal index ``j`` (this transform is implemented in [`Modes.ToSpace`](@ref) and [`Modes.to_space!`](@ref)):
 ```math
-\mathbf{E}(t, \mathbf{r_\perp}, z) = \frac{1}{2\pi} \int_{-\infty}^\infty \mathrm{d} \omega \sum_j \hat{\mathbf{e}}_j(\mathbf{r_\perp}, z) \tilde{E}_j(\omega, z) \mathrm{e}^{-i \omega t}\,,
+\mathbf{E}(t, \mathbf{r_\perp}, z) = \frac{1}{2\pi} \int_{-\infty}^\infty \mathrm{d} \omega \sum_j \hat{\mathbf{e}}_j(\mathbf{r_\perp}, z) \tilde{A}_j(\omega, z) \mathrm{e}^{-i \omega t}\,,
 ```
-where ``\hat{\mathbf{e}}_j(\mathbf{r_\perp}, z)`` is the orthonormal transverse field distribution of the ``j^{\mathrm{th}}`` mode and ``\tilde{E}_j(\omega, z)`` is the frequency-domain amplitude in mode ``j``. The mode fields ``\hat{\mathbf{e}}_j(\mathbf{r_\perp}, z)`` are taken to be independent of frequency but can depend on the propagation coordinate ``z`` (e.g. in tapered waveguides). They can be vector quantities if polarisations other than purely lineary ``x``- or ``y``-polarisations need to be taken into account. The modes are normalised such that ``\vert \tilde{E}_j(\omega, z) \vert^2`` gives the spectral energy density in mode ``j`` (when also taking into account the normalisation of the FFT), and equivalently ``\vert E_j(t, z)\vert^2`` gives the instantaneous power. The forward transform to reciprocal space is simply the overlap integral of the total field with each mode combined with the Fourier transform in time:
+where ``\hat{\mathbf{e}}_j(\mathbf{r_\perp}, z)`` is the orthonormal transverse field distribution of the ``j^{\mathrm{th}}`` mode and ``\tilde{A}_j(\omega, z)`` is the frequency-domain amplitude in mode ``j``. The mode fields ``\hat{\mathbf{e}}_j(\mathbf{r_\perp}, z)`` are taken to be independent of frequency but can depend on the propagation coordinate ``z`` (e.g. in tapered waveguides). They can be vector quantities if polarisations other than purely lineary ``x``- or ``y``-polarisations need to be taken into account. The modes are normalised such that ``\vert \tilde{A}_j(\omega, z) \vert^2`` gives the spectral energy density in mode ``j`` (when also taking into account the normalisation of the FFT), and equivalently ``\vert A_j(t, z)\vert^2`` gives the instantaneous power. The forward transform to reciprocal space is simply the overlap integral of the total field with each mode combined with the Fourier transform in time:
 ```math
-\tilde{E}_j(\omega, z) = \int_S \mathrm{d}^2\mathbf{r_\perp} \int_{-\infty}^\infty \mathrm{d} t\,\, \hat{\mathbf{e}}_j^*(\mathbf{r_\perp}, z) \cdot \mathbf{E}(t, \mathbf{r_\perp}, z) \mathrm{e}^{i \omega t}\,,
+\tilde{A}_j(\omega, z) = \int_S \mathrm{d}^2\mathbf{r_\perp} \int_{-\infty}^\infty \mathrm{d} t\,\, \hat{\mathbf{e}}_j^*(\mathbf{r_\perp}, z) \cdot \mathbf{E}(t, \mathbf{r_\perp}, z) \mathrm{e}^{i \omega t}\,,
 ```
 where ``S`` is the cross-sectional area of the waveguide. This transform is implemented in [`NonlinearRHS.TransModal`](@ref) for use within simulations and in [`Modes.overlap`](@ref) for decomposition of existing sampled fields. In both cases, the mode overlap integral is solved explicitly with a p-adaptive or h-adaptive cubature method.
 
@@ -25,13 +25,13 @@ where ``c`` is the speed of light in vacuum and ``n_\mathrm{eff}`` is complex, `
 
 With the modal power normalisation for ``\hat{\mathbf{e}}_j(\mathbf{r_\perp}, z)``, the normalisation factor ``N_{\mathrm{nl}}`` comes out as simply ``N_{\mathrm{nl}}=4``. The propagation equation, coupling the modes through the nonlinear polarisation, is therefore
 ```math
-\partial_z \tilde{E}_j(\omega, z) = i \left(\frac{\omega}{c} n_\mathrm{eff}(\omega, z) - \frac{\omega}{v}\right)\tilde{E}_j(\omega, z) + i\frac{\omega}{4} \tilde{\mathbf{P}}_\mathrm{nl}\,,
+\partial_z \tilde{A}_j(\omega, z) = i \left(\frac{\omega}{c} n_\mathrm{eff}(\omega, z) - \frac{\omega}{v}\right)\tilde{A}_j(\omega, z) + i\frac{\omega}{4} \tilde{\mathbf{P}}_\mathrm{nl}\,,
 ```
 where ``\tilde{\mathbf{P}}_\mathrm{nl}`` is given by
 ```math
 \tilde{\mathbf{P}}_\mathrm{nl} =  \int_S \mathrm{d}^2\mathbf{r_\perp} \int_{-\infty}^\infty \mathrm{d} t\,\, \hat{\mathbf{e}}_j^*(\mathbf{r_\perp}, z) \cdot \mathbf{P}_\mathrm{nl}\left[\mathbf{E}(t, \mathbf{r_\perp}, z)\right] \mathrm{e}^{i \omega t}
 ```
-and ``\mathbf{E}(t, \mathbf{r_\perp}, z)`` is obtained from the set of ``\tilde{E}_j(\omega, z)`` as above.
+and ``\mathbf{E}(t, \mathbf{r_\perp}, z)`` is obtained from the set of ``\tilde{A}_j(\omega, z)`` as above.
 
 The transverse coordinate ``\mathbf{r_\perp}`` for circular waveguides (e.g. hollow capillaries, optical fibres, and anti-resonant fibres) is in polar coordinates, ``\mathbf{r_\perp} = (r, \theta)``. For other waveguides (e.g. rectangular), it is Cartesian, ``\mathbf{r_\perp} = (x, y)``.
 
@@ -59,44 +59,22 @@ P_\mathrm{nl}\left(t, \mathbf{r}_\perp, z \right) = C\, E(t, \mathbf{r}_\perp, z
 ```
 where ``C`` is a constant which depends on the specific effect (e.g. for the Kerr effect, ``C`` becomes ``\varepsilon_0 \chi^{(3)}`` with ``\chi^{(3)}`` the third-order susceptibility of the nonlinear medium) and we have switched to *explicitly real-valued* and *scalar* fields to make the notation simpler; the same result can be obtained with vector fields and more algebra. Expanding the field in terms of its modal content as above, this turns into
 ```math
-P_\mathrm{nl}\left(t, \mathbf{r}_\perp, z \right) = C\, \Big[\sum_j \hat{e}_j(\mathbf{r_\perp}, z) E_j(t, z)\Big]^3\,,
+P_\mathrm{nl}\left(t, \mathbf{r}_\perp, z \right) = C\, \Big[\sum_j \hat{e}_j(\mathbf{r_\perp}, z) A_j(t, z)\Big]^3\,,
 ```
-where we have simply carried out the time-domain inverse Fourier transform to obtain ``E_j(t, z)``. For a single mode (``j=0`` only), this simplifies greatly to
+where we have simply carried out the time-domain inverse Fourier transform to obtain ``A_j(t, z)``. For a single mode, this simplifies greatly to
 ```math
-P_\mathrm{nl}\left(t, \mathbf{r}_\perp, z \right) = C\, \hat{e}_0(\mathbf{r_\perp}, z)^3 E_0(t, z)^3\,.
+P_\mathrm{nl}\left(t, \mathbf{r}_\perp, z \right) = C\, \hat{e}_0(\mathbf{r_\perp}, z)^3 A(t, z)^3\,.
 ```
 Now we can explicitly calculate the overlap integral with the single mode we are considering:
 ```math
 \begin{align*}
-P_\mathrm{nl}(t, z) &=  CE_0(t, z)^3\times\int_S \mathrm{d}^2\mathbf{r_\perp} \, \hat{e}_0^*(\mathbf{r_\perp}, z) \hat{e}_0(\mathbf{r_\perp}, z)^3\\
-&= CE_0(t, z)^3\int_S \mathrm{d}^2\mathbf{r_\perp} \, \hat{e}_0(\mathbf{r_\perp}, z)^4\\
-&\equiv CE_0(t, z)^3 \Gamma\,,
+P_\mathrm{nl}(t, z) &=  CA(t, z)^3\times\int_S \mathrm{d}^2\mathbf{r_\perp} \, \hat{e}_0^*(\mathbf{r_\perp}, z) \hat{e}_0(\mathbf{r_\perp}, z)^3\\[1em]
+&= CA(t, z)^3\int_S \mathrm{d}^2\mathbf{r_\perp} \, \hat{e}_0(\mathbf{r_\perp}, z)^4\,,
 \end{align*}
 ```
-where in the second step we have made use of the fact that we are considering real-valued fields and hence ``\hat{e}_0(\mathbf{r_\perp}, z)`` is also real. The constant ``\Gamma`` depends on the mode shape ``\hat{e}_0(\mathbf{r_\perp}, z)``, but crucially, only needs to be calculated *once*. If we now define a re-scaled **mode-averaged** modal field ``E'`` through
-```math
-E_0(t, z) = \sqrt{\frac{2}{\varepsilon_0 c \Gamma}}E'(t, z)\,,
-```
-then the UPPE reads
-```math
-\sqrt{\frac{2}{\varepsilon_0 c \Gamma}}\partial_z \tilde{E}'(\omega, z) = i \left(\frac{\omega}{c} n_\mathrm{eff}(\omega, z) - \frac{\omega}{v}\right)\sqrt{\frac{2}{\varepsilon_0 c \Gamma}}\tilde{E}'(\omega, z) + i\frac{\omega}{4} C\Big(\frac{2}{\varepsilon_0 c\Gamma}\Big)^{\frac{3}{2}}\Gamma \int_{-\infty}^\infty \mathrm{d} t\, E'(t, z)^3 \mathrm{e}^{i \omega t}\,.
-```
-The factors of ``\Gamma`` and ``\Gamma^{-\frac{3}{2}}`` in the final term combine to cancel with the other ``\Gamma^{-\frac{1}{2}}`` terms, so that we arrive at the **mode-averaged UPPE**
-```math
-\partial_z \tilde{E}'(\omega, z) = i \left(\frac{\omega}{c} n_\mathrm{eff}(\omega, z) - \frac{\omega}{v}\right)\tilde{E}'(\omega, z) + i\frac{\omega}{4} \frac{2}{\varepsilon_0 c} \int_{-\infty}^\infty \mathrm{d} t\, P_\mathrm{nl}\left[E'(t, z)\right] \mathrm{e}^{i \omega t}\,.
-```
-This now includes only a single inverse Fourier transform to obtain ``E'(t, z)`` followed by the calculation of ``P_\mathrm{nl}`` and then a forward transform. However, note that we have played a trick in this last step of the derivation: this equation is **only valid for third-order responses** but we have now written it for an arbitrary polarisation ``P_\mathrm{nl}\left[E'(t, z)\right]``. The above derivation quickly fails for other polarisation types, most importantly photoionisation. That means that mode-averaged propagation is a *significant* approximation whenever photoionisation and plasma effects are important.
+where ``A`` is now the modal amplitude in the single mode. In the second step we have made use of the fact that we are considering real-valued fields and hence ``\hat{e}_0(\mathbf{r_\perp}, z)`` is also real.
 
-The mode-averaged UPPE as written above is very useful, but the scaling from ``E`` to ``E'`` changes the normalisation: ``\vert E'(t, z) \vert^2`` no longer gives the instantaneous power. To remain consistent with modal propagation simulations (e.g. for data analysis), Luna internally uses the same normalisation for both, that is, the propagating field is ``E(z, t)`` and we only switch to ``E'(z, t)`` to calculate the nonlinear polarisation. This leads to the appearance of an additional factor of ``\sqrt{\Gamma}`` in the equation
-```math
-\begin{align*}
-\partial_z \sqrt{\Gamma}\tilde{E}(\omega, z) &= i\sqrt{\Gamma} \left(\frac{\omega}{c} n_\mathrm{eff}(\omega, z) - \frac{\omega}{v}\right)\tilde{E}(\omega, z) + i\frac{\omega}{4} \int_{-\infty}^\infty \mathrm{d} t\, P_\mathrm{nl}\left[E'(t, z)\right] \mathrm{e}^{i \omega t}\\
-\Rightarrow \partial_z\tilde{E}(\omega, z) &= i \left(\frac{\omega}{c} n_\mathrm{eff}(\omega, z) - \frac{\omega}{v}\right)\tilde{E}(\omega, z) + i\frac{\omega}{4\sqrt{\Gamma}} \int_{-\infty}^\infty \mathrm{d} t\, P_\mathrm{nl}\left[E'(t, z)\right] \mathrm{e}^{i \omega t}\,.
-\end{align*}
-```
-
-### Connection to the effective area
-The mode normalisation in Luna is chosen such that the absolute value squared of the modal field amplitudes ``E_j(t, z)`` is the instantaneous power. For this to be fulfilled, we need
+The mode normalisation in Luna is chosen such that the absolute value squared of the modal field amplitudes ``A_j(t, z)`` is the instantaneous power. For this to be fulfilled, we need
 ```math
 \frac{1}{2} c \varepsilon_0 \int_S \mathrm{d}^2\mathbf{r_\perp} \left\vert \hat{e}_j(\mathbf{r_\perp}, z) \right\vert^2 = 1\,.
 ```
@@ -104,14 +82,56 @@ This, in turn, means that the *effective area* of the mode,
 ```math
 A_{\mathrm{eff}, j}(z) = \frac{\left(\int_S \mathrm{d}^2\mathbf{r_\perp} \,\left\vert \hat{e}_j(\mathbf{r}_\perp, z)\right\vert^2\right)^2}{\int_S \mathrm{d}^2\mathbf{r_\perp}  \,\left\vert \hat{e}_j(\mathbf{r}_\perp, z)\right\vert^4}\,,
 ```
-is given by
+for the single mode we are considering is
 ```math
-A_\mathrm{eff} = \Big(\frac{1}{4} c^2 \varepsilon_0^2 \Gamma \Big)^{-1}
+A_\mathrm{eff} = \Big(\frac{1}{4} c^2 \varepsilon_0^2 \int_S \mathrm{d}^2\mathbf{r_\perp} \, \hat{e}_0(\mathbf{r_\perp}, z)^4 \Big)^{-1}\,.
 ```
-with the scaling constant ``\Gamma`` as defined above. Note that ``A_\mathrm{eff}`` is **independent of the normalisation**, because the overall power of ``\hat{e}_j`` and any constants inside it is the same in the numerator and denominator. Hence the scaling factor can be obtained from the effective area as
+Note that ``A_\mathrm{eff}`` is **independent of the normalisation**, because the overall power of ``\hat{e}_j`` and any constants inside it is the same in the numerator and denominator. From this we can see that we can replace the integral expression in the projection of ``P_\mathrm{nl}`` with
 ```math
-\Gamma = \Big(\frac{1}{4} c^2 \varepsilon_0^2 A_\mathrm{eff} \Big)^{-1}\,.
+\int_S \mathrm{d}^2\mathbf{r_\perp} \, \hat{e}_0(\mathbf{r_\perp}, z)^4 = \frac{4}{\varepsilon_0^2c^2 A_\mathrm{eff}}\,.
 ```
+We can now write down the **single-mode UPPE:**
+```math
+
+\partial_z \tilde{A}(\omega, z) = i \left(\frac{\omega}{c} n_\mathrm{eff}(\omega, z) - \frac{\omega}{v}\right)\tilde{A}(\omega, z)
+ + i\frac{\omega}{4} C\frac{4}{\varepsilon_0^2c^2 A_\mathrm{eff}} \int_{-\infty}^\infty \mathrm{d} t\, A(t, z)^3 \mathrm{e}^{i \omega t}\,.
+```
+Crucially, the effective area depends on the mode shape ``\hat{e}_0(\mathbf{r_\perp}, z)``, but only needs to be calculated *once* (assuming the cross-section of the waveguide does not change along its length). When only third-order nonlinear effects are present, the single-mode UPPE is exactly equivalent to explicitly solving the projection integral, but *much* faster. However, it has two important drawbacks:
+
+1. For obvious reasons, inter-modal coupling mediated by the nonlinearity is completely ignored.
+2. The equation only works for third-order nonlinear effects, and hence photoionisation and plasma dynamics cannot be modelled in this way.
+
+We can derive a different single-mode equation which can treat other nonlinear effects approximately. As written above, in the single-mode UPPE only the modal amplitude ``A`` appears. We now define a re-scaled **mode-averaged field** ``E_\mathrm{av}`` through
+```math
+A(t, z) = \sqrt{\frac{1}{2}\varepsilon_0 c A_\mathrm{eff}}E_\mathrm{av}(t, z)\,.
+```
+Note that, because ``\vert A(t, z)\vert^2`` has units of power, ``E_\mathrm{av}`` is in fact an electric field (with units of ``\mathrm{V/m}``). We can also define the *mode-averaged intensity* by
+```math
+I_\mathrm{av} = \frac{1}{2}\varepsilon_0 c \vert E_\mathrm{av}\vert^2 = \frac{\vert A(t, z)\vert^2}{A_\mathrm{eff}}\,.
+```
+Plugging in the definition of ``E_\mathrm{av}``, the UPPE reads
+```math
+\begin{align*}
+\sqrt{\frac{1}{2}\varepsilon_0 c A_\mathrm{eff}}\partial_z \tilde{E}'(\omega, z) &= i \left(\frac{\omega}{c} n_\mathrm{eff}(\omega, z) - \frac{\omega}{v}\right)\sqrt{\frac{1}{2}\varepsilon_0 c A_\mathrm{eff}}\tilde{E}'(\omega, z)\\[1em]
+&\qquad + i\frac{\omega}{4} C\Big(\frac{1}{2}\varepsilon_0 c A_\mathrm{eff}\Big)^{\frac{3}{2}}\frac{4}{\varepsilon_0^2c^2 A_\mathrm{eff}} \int_{-\infty}^\infty \mathrm{d} t\, E_\mathrm{av}(t, z)^3 \mathrm{e}^{i \omega t}\,.
+\end{align*}
+```
+Cancelling the various constants, we arrive at the **mode-averaged field UPPE**
+```math
+\partial_z \tilde{E}_\mathrm{av}(\omega, z) = i \left(\frac{\omega}{c} n_\mathrm{eff}(\omega, z) - \frac{\omega}{v}\right)\tilde{E}_\mathrm{av}(\omega, z) + i\frac{\omega}{4} \frac{2}{\varepsilon_0 c} \int_{-\infty}^\infty \mathrm{d} t\, P_\mathrm{nl}\left[E_\mathrm{av}(t, z)\right] \mathrm{e}^{i \omega t}\,.
+```
+This now includes only a single inverse Fourier transform to obtain ``E_\mathrm{av}(t, z)`` followed by the calculation of ``P_\mathrm{nl}`` and then a forward transform. This equation is **still only valid for third-order responses** but we have now written it for an arbitrary polarisation ``P_\mathrm{nl}\left[E_\mathrm{av}(t, z)\right]``. Because ``E_\mathrm{av}`` is (a version of) the actual electric field, we can calculate arbitrary polarisation contributions, including the photoionisation and plasma term. However, this is still a significant approximation. For example, the mode-averaged intensity is approximately half of the on-axis intensity for the fundamental mode of a capillary fibre. Due to the exponential scaling of strong-field ionisation with intensity, this means that the peak ionisation fraction can be underestimated significantly. Only fully mode-resolved (and multi-mode) propagation can accurately model that situation.
+
+The mode-averaged field UPPE as written above is very useful, but the scaling from ``A`` to ``E_\mathrm{av}`` changes the normalisation: ``\vert E_\mathrm{av}(t, z) \vert^2`` no longer gives the instantaneous power. To remain consistent with modal propagation simulations (e.g. for data analysis), Luna internally uses the same normalisation for both, which leads to a "hybrid" equation. The propagating quantity (and hence the simulation output) is ``A(z, t)`` and we switch to ``E_\mathrm{av}(z, t)`` to calculate the nonlinear polarisation. This leads to the appearance of an additional factor of in the equation
+```math
+\begin{align*}
+\left(\frac{1}{2}\varepsilon_0 c A_\mathrm{eff}\right)^{-\frac{1}{2}}\partial_z \tilde{A}(\omega, z) &= i\left(\frac{1}{2}\varepsilon_0 c A_\mathrm{eff}\right)^{-\frac{1}{2}} \left(\frac{\omega}{c} n_\mathrm{eff}(\omega, z) - \frac{\omega}{v}\right)\tilde{A}(\omega, z) + i\frac{\omega}{4} \frac{2}{\varepsilon_0 c} \int_{-\infty}^\infty \mathrm{d} t\, P_\mathrm{nl}\left[E_\mathrm{av}(t, z)\right] \mathrm{e}^{i \omega t}\\[1em]
+
+\Rightarrow \partial_z\tilde{A}(\omega, z) &= i \left(\frac{\omega}{c} n_\mathrm{eff}(\omega, z) - \frac{\omega}{v}\right)\tilde{A}(\omega, z) + i\frac{\omega}{4}\sqrt{\frac{2A_\mathrm{eff}}{\varepsilon_0 c} }\int_{-\infty}^\infty \mathrm{d} t\, P_\mathrm{nl}\left[E_\mathrm{av}(t, z)\right] \mathrm{e}^{i \omega t}\,.
+\end{align*}
+```
+
+
 
 ## Radially symmetric free-space
 

--- a/docs/src/model/modal_decompositions.md
+++ b/docs/src/model/modal_decompositions.md
@@ -83,6 +83,14 @@ The factors of ``\Gamma`` and ``\Gamma^{-\frac{3}{2}}`` in the final term combin
 ```
 This now includes only a single inverse Fourier transform to obtain ``E'(t, z)`` followed by the calculation of ``P_\mathrm{nl}`` and then a forward transform. However, note that we have played a trick in this last step of the derivation: this equation is **only valid for third-order responses** but we have now written it for an arbitrary polarisation ``P_\mathrm{nl}\left[E'(t, z)\right]``. The above derivation quickly fails for other polarisation types, most importantly photoionisation. That means that mode-averaged propagation is a *significant* approximation whenever photoionisation and plasma effects are important.
 
+The mode-averaged UPPE as written above is very useful, but the scaling from ``E`` to ``E'`` changes the normalisation: ``\vert E'(t, z) \vert^2`` no longer gives the instantaneous power. To remain consistent with modal propagation simulations (e.g. for data analysis), Luna internally uses the same normalisation for both, that is, the propagating field is ``E(z, t)`` and we only switch to ``E'(z, t)`` to calculate the nonlinear polarisation. This leads to the appearance of an additional factor of ``\sqrt{\Gamma}`` in the equation
+```math
+\begin{align*}
+\partial_z \sqrt{\Gamma}\tilde{E}(\omega, z) &= i\sqrt{\Gamma} \left(\frac{\omega}{c} n_\mathrm{eff}(\omega, z) - \frac{\omega}{v}\right)\tilde{E}(\omega, z) + i\frac{\omega}{4} \int_{-\infty}^\infty \mathrm{d} t\, P_\mathrm{nl}\left[E'(t, z)\right] \mathrm{e}^{i \omega t}\\
+\Rightarrow \partial_z\tilde{E}(\omega, z) &= i \left(\frac{\omega}{c} n_\mathrm{eff}(\omega, z) - \frac{\omega}{v}\right)\tilde{E}(\omega, z) + i\frac{\omega}{4\sqrt{\Gamma}} \int_{-\infty}^\infty \mathrm{d} t\, P_\mathrm{nl}\left[E'(t, z)\right] \mathrm{e}^{i \omega t}\,.
+\end{align*}
+```
+
 ### Connection to the effective area
 The mode normalisation in Luna is chosen such that the absolute value squared of the modal field amplitudes ``E_j(t, z)`` is the instantaneous power. For this to be fulfilled, we need
 ```math
@@ -92,11 +100,14 @@ This, in turn, means that the *effective area* of the mode,
 ```math
 A_{\mathrm{eff}, j}(z) = \frac{\left(\int_S \mathrm{d}^2\mathbf{r_\perp} \,\left\vert \hat{e}_j(\mathbf{r}_\perp, z)\right\vert^2\right)^2}{\int_S \mathrm{d}^2\mathbf{r_\perp}  \,\left\vert \hat{e}_j(\mathbf{r}_\perp, z)\right\vert^4}\,,
 ```
-which is **independent of the normalisation** (since the overall power of ``\hat{e}_j`` and any constants inside it is the same in the numerator and denominator), is given by
+is given by
 ```math
 A_\mathrm{eff} = \Big(\frac{1}{4} c^2 \varepsilon_0^2 \Gamma \Big)^{-1}
 ```
-with the scaling constant ``\Gamma`` as defined above.
+with the scaling constant ``\Gamma`` as defined above. Note that ``A_\mathrm{eff}`` is **independent of the normalisation**, because the overall power of ``\hat{e}_j`` and any constants inside it is the same in the numerator and denominator. Hence the scaling factor can be obtained from the effective area as
+```math
+\Gamma = \Big(\frac{1}{4} c^2 \varepsilon_0^2 A_\mathrm{eff} \Big)^{-1}/,.
+```
 
 ## Radially symmetric free-space
 

--- a/docs/src/model/modal_decompositions.md
+++ b/docs/src/model/modal_decompositions.md
@@ -84,11 +84,19 @@ The factors of ``\Gamma`` and ``\Gamma^{-\frac{3}{2}}`` in the final term combin
 This now includes only a single inverse Fourier transform to obtain ``E'(t, z)`` followed by the calculation of ``P_\mathrm{nl}`` and then a forward transform. However, note that we have played a trick in this last step of the derivation: this equation is **only valid for third-order responses** but we have now written it for an arbitrary polarisation ``P_\mathrm{nl}\left[E'(t, z)\right]``. The above derivation quickly fails for other polarisation types, most importantly photoionisation. That means that mode-averaged propagation is a *significant* approximation whenever photoionisation and plasma effects are important.
 
 ### Connection to the effective area
-The mode normalisation in Luna is chosen such that the absolute value squared of the modal field amplitudes ``E_j(t, z)`` is the instantaneous power. This means that
+The mode normalisation in Luna is chosen such that the absolute value squared of the modal field amplitudes ``E_j(t, z)`` is the instantaneous power. For this to be fulfilled, we need
 ```math
-\left\vert E_j(t, z)\right\vert^2 = \frac{1}{2} c \varepsilon_0 \int_S \left\vert E(t, \mathbf{r}_\perp, z) \right\vert^2
+\frac{1}{2} c \varepsilon_0 \int_S \mathrm{d}^2\mathbf{r_\perp} \left\vert \hat{e}_j(\mathbf{r_\perp}, z) \right\vert^2 = 1\,.
 ```
-
+This, in turn, means that the *effective area* of the mode,
+```math
+A_{\mathrm{eff}, j}(z) = \frac{\left(\int_S \mathrm{d}^2\mathbf{r_\perp} \,\left\vert \hat{e}_j(\mathbf{r}_\perp, z)\right\vert^2\right)^2}{\int_S \mathrm{d}^2\mathbf{r_\perp}  \,\left\vert \hat{e}_j(\mathbf{r}_\perp, z)\right\vert^4}\,,
+```
+which is **independent of the normalisation** (since the overall power of ``\hat{e}_j`` and any constants inside it is the same in the numerator and denominator), is given by
+```math
+A_\mathrm{eff} = \Big(\frac{1}{4} c^2 \varepsilon_0^2 \Gamma \Big)^{-1}
+```
+with the scaling constant ``\Gamma`` as defined above.
 
 ## Radially symmetric free-space
 

--- a/docs/src/model/modal_decompositions.md
+++ b/docs/src/model/modal_decompositions.md
@@ -67,19 +67,23 @@ P_\mathrm{nl}\left(t, \mathbf{r}_\perp, z \right) = C\, \hat{e}_0(\mathbf{r_\per
 ```
 Now we can explicitly calculate the overlap integral with the single mode we are considering:
 ```math
-P_\mathrm{nl}(t, z) =  CE_0(t, z)^3\times\int_S \mathrm{d}^2\mathbf{r_\perp} \, \hat{e}_0^*(\mathbf{r_\perp}, z) \hat{e}_0(\mathbf{r_\perp}, z)^3 = CE_0(t, z)^3\int_S \mathrm{d}^2\mathbf{r_\perp} \, \hat{e}_0(\mathbf{r_\perp}, z)^4 \equiv CE_0(t, z)^3 \Gamma\,,
+\begin{align*}
+P_\mathrm{nl}(t, z) &=  CE_0(t, z)^3\times\int_S \mathrm{d}^2\mathbf{r_\perp} \, \hat{e}_0^*(\mathbf{r_\perp}, z) \hat{e}_0(\mathbf{r_\perp}, z)^3\\
+&= CE_0(t, z)^3\int_S \mathrm{d}^2\mathbf{r_\perp} \, \hat{e}_0(\mathbf{r_\perp}, z)^4\\
+&\equiv CE_0(t, z)^3 \Gamma\,,
+\end{align*}
 ```
 where in the second step we have made use of the fact that we are considering real-valued fields and hence ``\hat{e}_0(\mathbf{r_\perp}, z)`` is also real. The constant ``\Gamma`` depends on the mode shape ``\hat{e}_0(\mathbf{r_\perp}, z)``, but crucially, only needs to be calculated *once*. If we now define a re-scaled **mode-averaged** modal field ``E'`` through
 ```math
-E_0(t, z) = \frac{E'(t, z)}{\sqrt{\Gamma}}\,,
+E_0(t, z) = \sqrt{\frac{2}{\varepsilon_0 c \Gamma}}E'(t, z)\,,
 ```
 then the UPPE reads
 ```math
-\Gamma^{-\frac{1}{2}}\partial_z \tilde{E}'(\omega, z) = i \left(\frac{\omega}{c} n_\mathrm{eff}(\omega, z) - \frac{\omega}{v}\right)\Gamma^{-\frac{1}{2}}\tilde{E}'(\omega, z) + i\frac{\omega}{4} C\Gamma\times\Gamma^{-\frac{3}{2}} \int_{-\infty}^\infty \mathrm{d} t\, E'(t, z)^3 \mathrm{e}^{i \omega t}\,.
+\sqrt{\frac{2}{\varepsilon_0 c \Gamma}}\partial_z \tilde{E}'(\omega, z) = i \left(\frac{\omega}{c} n_\mathrm{eff}(\omega, z) - \frac{\omega}{v}\right)\sqrt{\frac{2}{\varepsilon_0 c \Gamma}}\tilde{E}'(\omega, z) + i\frac{\omega}{4} C\Big(\frac{2}{\varepsilon_0 c\Gamma}\Big)^{\frac{3}{2}}\Gamma \int_{-\infty}^\infty \mathrm{d} t\, E'(t, z)^3 \mathrm{e}^{i \omega t}\,.
 ```
 The factors of ``\Gamma`` and ``\Gamma^{-\frac{3}{2}}`` in the final term combine to cancel with the other ``\Gamma^{-\frac{1}{2}}`` terms, so that we arrive at the **mode-averaged UPPE**
 ```math
-\partial_z \tilde{E}'(\omega, z) = i \left(\frac{\omega}{c} n_\mathrm{eff}(\omega, z) - \frac{\omega}{v}\right)\tilde{E}'(\omega, z) + i\frac{\omega}{4} \int_{-\infty}^\infty \mathrm{d} t\, P_\mathrm{nl}\left[E'(t, z)\right] \mathrm{e}^{i \omega t}\,.
+\partial_z \tilde{E}'(\omega, z) = i \left(\frac{\omega}{c} n_\mathrm{eff}(\omega, z) - \frac{\omega}{v}\right)\tilde{E}'(\omega, z) + i\frac{\omega}{4} \frac{2}{\varepsilon_0 c} \int_{-\infty}^\infty \mathrm{d} t\, P_\mathrm{nl}\left[E'(t, z)\right] \mathrm{e}^{i \omega t}\,.
 ```
 This now includes only a single inverse Fourier transform to obtain ``E'(t, z)`` followed by the calculation of ``P_\mathrm{nl}`` and then a forward transform. However, note that we have played a trick in this last step of the derivation: this equation is **only valid for third-order responses** but we have now written it for an arbitrary polarisation ``P_\mathrm{nl}\left[E'(t, z)\right]``. The above derivation quickly fails for other polarisation types, most importantly photoionisation. That means that mode-averaged propagation is a *significant* approximation whenever photoionisation and plasma effects are important.
 
@@ -106,7 +110,7 @@ A_\mathrm{eff} = \Big(\frac{1}{4} c^2 \varepsilon_0^2 \Gamma \Big)^{-1}
 ```
 with the scaling constant ``\Gamma`` as defined above. Note that ``A_\mathrm{eff}`` is **independent of the normalisation**, because the overall power of ``\hat{e}_j`` and any constants inside it is the same in the numerator and denominator. Hence the scaling factor can be obtained from the effective area as
 ```math
-\Gamma = \Big(\frac{1}{4} c^2 \varepsilon_0^2 A_\mathrm{eff} \Big)^{-1}/,.
+\Gamma = \Big(\frac{1}{4} c^2 \varepsilon_0^2 A_\mathrm{eff} \Big)^{-1}\,.
 ```
 
 ## Radially symmetric free-space

--- a/docs/src/model/model.md
+++ b/docs/src/model/model.md
@@ -14,7 +14,7 @@ P_{\mathrm{nl}}(\omega, \mathbf{k}_\perp, z) = \int_{-\infty}^{\infty} \mathcal{
 ```
 where ``\mathcal{T}_\perp`` is a transform from (transverse) real space to reciprocal space (i.e. spatial frequency), ``\mathbf{r}_\perp`` is the transverse spatial coordinate, ``t`` is time, and  ``\mathcal{P}`` is an operator which calculates the nonlinear response of the medium given an electric field. Naturally, the real-space field ``E(t, \mathbf{r}_\perp, z)`` first has to be obtained from ``E(\omega, \mathbf{k}_\perp, z)``:
 ```math
-E(t, \mathbf{r}_\perp, z)  = \mathcal{T}_\perp^{-1}\Big[E(\omega, \mathbf{k}_\perp, z)\Big]\,,
+E(t, \mathbf{r}_\perp, z)  = \int_{-\infty}^{\infty} \mathrm{d}\omega \mathcal{T}_\perp^{-1}\Big[E(\omega, \mathbf{k}_\perp, z)\Big]\mathrm{e}^{-i\omega t}\,,
 ```
 where ``\mathcal{T}_\perp^{-1}`` is simply the inverse of ``\mathcal{T}_\perp`` so transforms from transverse reciprocal space to real space. The chief difference between variations of the UPPE implemented in `Luna` is the definition of ``\mathbf{k}_\perp`` and ``\mathcal{T}_\perp``, that is, the choice of [Modal decompositions](@ref) of the field.
 

--- a/src/NonlinearRHS.jl
+++ b/src/NonlinearRHS.jl
@@ -367,15 +367,13 @@ function (t::TransModeAvg)(nl, Eω, z)
 end
 
 function norm_mode_average(grid, βfun!, aeff; shock=true)
-    β = zeros(Float64, length(grid.ω))
-    shockterm = shock ? grid.ω.^2 : grid.ω .* PhysData.wlfreq(grid.referenceλ)
-    pre = @. -im*shockterm/(2*PhysData.c^(3/2)*sqrt(2*PhysData.ε_0))
+    shockterm = shock ? grid.ω : PhysData.wlfreq(grid.referenceλ)
+    pre = @. -im*shockterm/4 / nlscale
     function norm!(nl, z)
-        βfun!(β, z)
         sqrtaeff = sqrt(aeff(z))
         for i in eachindex(nl)
             !grid.sidx[i] && continue
-            nl[i] *= pre[i]*sqrtaeff/β[i]
+            nl[i] *= pre[i]*sqrtaeff
         end
     end
 end

--- a/src/NonlinearRHS.jl
+++ b/src/NonlinearRHS.jl
@@ -367,13 +367,15 @@ function (t::TransModeAvg)(nl, Eω, z)
 end
 
 function norm_mode_average(grid, βfun!, aeff; shock=true)
-    shockterm = shock ? grid.ω : PhysData.wlfreq(grid.referenceλ)
-    pre = @. -im*shockterm/4 / nlscale
+    β = zeros(Float64, length(grid.ω))
+    shockterm = shock ? grid.ω.^2 : grid.ω .* PhysData.wlfreq(grid.referenceλ)
+    pre = @. -im*shockterm/4 / nlscale / PhysData.c
     function norm!(nl, z)
+        βfun!(β, z)
         sqrtaeff = sqrt(aeff(z))
         for i in eachindex(nl)
             !grid.sidx[i] && continue
-            nl[i] *= pre[i]*sqrtaeff
+            nl[i] *= pre[i]/β[i]*sqrtaeff
         end
     end
 end


### PR DESCRIPTION
This has come up as a question over email a few times now, so I wrote it up properly.

One question which came to mind as I was writing this: I think we're currently being inconsistent regarding the mode normalisation and the prefactor for the nonlinear polarisation in mode-averaged propagation. We currently have `β` in the prefactor but not in the normalisation (`Modes.N`), even though the prefactor *arises from* the normalisation. Here I've changed `NonlinearRHS.norm_mode_average` to be consistent with the normalisation (ie implicitly assuming that `n_eff` is approximately 1). But I'm open to being convinced that we should do it differently.

You can see a semi-rendered version of the markdown at https://github.com/chrisbrahms/Luna.jl/blob/moredocs/docs/src/model/modal_decompositions.md