### PR TITLE
use stale_age for pidlock in FFTWcache

### DIFF
--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -88,9 +88,9 @@ function loadFFTwisdom()
     isdir(cachedir()) || mkpath(cachedir())
     if isfile(fpath)
         Logging.@info("Found FFTW wisdom at $fpath")
-        pidlock = mkpidlock(lockpath)
-        ret = FFTW.import_wisdom(fpath)
-        close(pidlock)
+        mkpidlock(lockpath; stale_age=600) do
+            FFTW.import_wisdom(fpath)
+        end
     else
         Logging.@info("No FFTW wisdom found")
     end
@@ -99,11 +99,11 @@ end
 function saveFFTwisdom()
     fpath = joinpath(cachedir(), "FFTWcache_$(FFTWthreads())threads")
     lockpath = joinpath(cachedir(), "FFTWlock")
-    pidlock = mkpidlock(lockpath)
-    isfile(fpath) && rm(fpath)
-    isdir(cachedir()) || mkpath(cachedir())
-    FFTW.export_wisdom(fpath)
-    close(pidlock)
+    mkpidlock(lockpath; stale_age=600) do
+        isfile(fpath) && rm(fpath)
+        isdir(cachedir()) || mkpath(cachedir())
+        FFTW.export_wisdom(fpath)
+    end
     Logging.@info("FFTW wisdom saved to $fpath")
 end
 


### PR DESCRIPTION
Just encountered a bug where a killed process left behind a `pidlock` on the FFTW cache, blocking all subsequent Luna runs. This is because without the `stale_age` argument, `mkpidlock` waits indefinitely. We previously solved the same issue for the PPT cache in #349 .