### PR TITLE
RFC: Stop saving "dumps" of the simulation

### DIFF
--- a/examples/low_level_interface/freespace/chi2_benchmarking.jl
+++ b/examples/low_level_interface/freespace/chi2_benchmarking.jl
@@ -1,0 +1,37 @@
+using Luna
+using BenchmarkTools
+import Rotations: RotZY, RotYZ, RotMatrix, RotMatrix3
+import LinearAlgebra: mul!
+using Metal
+
+θ = deg2rad(23.3717)
+ϕ = deg2rad(30)
+material = :BBO
+
+Et = rand(2^12, 2)
+out = zero(Et)
+
+c = Nonlinear.Chi2Field(θ, ϕ, PhysData.χ2(material))
+# r = Nonlinear.Kerr_field(PhysData.χ3(material))
+
+function toprofile(n)
+    for i in 1:n
+        c(out, Et, 1)
+    end
+end
+##
+@profview toprofile(1)
+@profview toprofile(100)
+@btime c(out, Et, 1)
+
+##
+Enl2 = rand(2^12, 6)'
+Et2 = rand(2^12, 3)'
+##
+Et2_m = MtlArray(convert(Matrix{Float32}, Et2))
+χ2_m = MtlArray(convert(Matrix{Float32}, c.χ2_toLab))
+Enl2_m = MtlArray(convert(Matrix{Float32}, Enl2))
+@btime mul!(Et2_m, χ2_m, Enl2_m)
+
+##
+@btime mul!(Et2, c.χ2_toLab, Enl2)

--- a/src/Luna.jl
+++ b/src/Luna.jl
@@ -301,16 +301,6 @@ simtype(g, t, l) = Dict("field" => gridtype(g),
                         "transform" => string(t),
                         "linop" => linoptype(l))
 
-function dumps(t, l)
-    io = IOBuffer()
-    dump(io, t)
-    tr = String(take!(io))
-    io = IOBuffer()
-    dump(io, l)
-    lo = String(take!(io))
-    Dict("transform" => tr, "linop" => lo)
-end
-
 function run(Eω, grid,
              linop, transform, FT, output;
              min_dz=0, max_dz=grid.zmax/2, init_dz=1e-4, z0=0.0,

--- a/src/Luna.jl
+++ b/src/Luna.jl
@@ -336,7 +336,6 @@ function run(Eω, grid,
 
     output(Grid.to_dict(grid), group="grid")
     output(simtype(grid, transform, linop), group="simulation_type")
-    output(dumps(transform, linop), group="dumps")
 
     RK45.solve_precon(
         transform, linop, Eω, z0, init_dz, grid.zmax, stepfun=stepfun,


### PR DESCRIPTION
We currently save string "dumps" of the entire simulation framework (basically the content of every object including all fixed numerical data). For large simulations, especially full 3D free space, this becomes very large and takes a considerable time to run--several minutes in the worst case I've seen. In general it can make up up to 50% of the file size when saving individual simulations to disk.

The original intention was to give more information about past simulations and for bug-hunting. As far as I know we have never used this. Maybe we just get rid of it?