### PR TITLE
RFC: Stop saving "dumps" of the simulation

### DIFF
--- a/src/Luna.jl
+++ b/src/Luna.jl
@@ -301,16 +301,6 @@ simtype(g, t, l) = Dict("field" => gridtype(g),
                         "transform" => string(t),
                         "linop" => linoptype(l))
 
-function dumps(t, l)
-    io = IOBuffer()
-    dump(io, t)
-    tr = String(take!(io))
-    io = IOBuffer()
-    dump(io, l)
-    lo = String(take!(io))
-    Dict("transform" => tr, "linop" => lo)
-end
-
 function run(Eω, grid,
              linop, transform, FT, output;
              min_dz=0, max_dz=grid.zmax/2, init_dz=1e-4, z0=0.0,
@@ -336,7 +326,6 @@ function run(Eω, grid,
 
     output(Grid.to_dict(grid), group="grid")
     output(simtype(grid, transform, linop), group="simulation_type")
-    output(dumps(transform, linop), group="dumps")
 
     RK45.solve_precon(
         transform, linop, Eω, z0, init_dz, grid.zmax, stepfun=stepfun,


### PR DESCRIPTION
Re-up of #382 

We currently save string "dumps" of the entire simulation framework (basically the content of every object including all fixed numerical data). For large simulations, especially full 3D free space, this becomes very large and takes a considerable time to run--several minutes in the worst case I've seen. In general it can make up up to 50% of the file size when saving individual simulations to disk.

The original intention was to give more information about past simulations and for bug-hunting. As far as I know we have never used this. Maybe we just get rid of it?
