### PR TITLE
Preionisation

### DIFF
--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -316,6 +316,8 @@ In this case, all keyword arguments except for `λ0` are ignored.
     the ionisation. See [`ionrate_fun_PPT`](@ref Ionisation.ionrate_fun_PPT) for possible
     keyword arguments.
 - `preionfrac::Float64`: fraction of the gas that is pre-ionised before the pulse. Defaults to `0.0`.
+    Note that this is a very simplistic model of pre-ionisation and should be used with
+    caution.
 - `thg::Bool`: Whether to include third-harmonic generation. Defaults to `true` for
     full-field simulations and to `false` for envelope simulations.
 If `raman` is `true`, then the following options apply:

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -315,6 +315,7 @@ In this case, all keyword arguments except for `λ0` are ignored.
     plasma nonlinearity, this allows for fine-tuning of the options in calculating
     the ionisation. See [`ionrate_fun_PPT`](@ref Ionisation.ionrate_fun_PPT) for possible
     keyword arguments.
+- `preionfrac::Float64`: fraction of the gas that is pre-ionised before the pulse. Defaults to `0.0`.
 - `thg::Bool`: Whether to include third-harmonic generation. Defaults to `true` for
     full-field simulations and to `false` for envelope simulations.
 If `raman` is `true`, then the following options apply:
@@ -359,7 +360,7 @@ function prop_capillary_args(radius, flength, gas, pressure;
                         shotnoise=true,
                         modes=:HE11, model=:full, loss=true,
                         raman=nothing, kerr=true, plasma=nothing,
-                        PPT_options=Dict{Symbol, Any}(),
+                        PPT_options=Dict{Symbol, Any}(), preionfrac=0.0,
                         rotation=true, vibration=true,
                         saveN=201, filepath=nothing,
                         scan=nothing, scanidx=nothing, filename=nothing)
@@ -373,7 +374,8 @@ function prop_capillary_args(radius, flength, gas, pressure;
     mode_s = makemode_s(modes, flength, radius, gas, pressure, model, loss, pol)
     check_orth(mode_s)
     density = makedensity(flength, gas, pressure)
-    resp = makeresponse(grid, gas, raman, kerr, plasma, thg, pol, rotation, vibration, PPT_options)
+    resp = makeresponse(grid, gas, raman, kerr, plasma, thg, pol, rotation, vibration,
+                        PPT_options, preionfrac)
     inputs = makeinputs(mode_s, λ0, pulses, τfwhm, τw, ϕ,
                         power, energy, pulseshape, polarisation, propagator)
     inputs = shotnoise_maybe(inputs, mode_s, shotnoise)
@@ -512,7 +514,7 @@ function makedensity(flength, gas, pressure)
 end
 
 function makeresponse(grid::Grid.RealGrid, gas, raman, kerr, plasma, thg, pol,
-                      rotation, vibration, PPT_options)
+                      rotation, vibration, PPT_options, preionfrac)
     out = Any[]
     if kerr
         if thg
@@ -521,7 +523,7 @@ function makeresponse(grid::Grid.RealGrid, gas, raman, kerr, plasma, thg, pol,
             push!(out, Nonlinear.Kerr_field_nothg(PhysData.γ3_gas(gas), length(grid.to)))
         end
     end
-    makeplasma!(out, grid, gas, plasma, pol, PPT_options)
+    makeplasma!(out, grid, gas, plasma, pol, PPT_options, preionfrac)
     if isnothing(raman)
         raman = gas in (:N2, :H2, :D2, :N2O, :CH4, :SF6)
     end
@@ -538,7 +540,7 @@ function makeresponse(grid::Grid.RealGrid, gas, raman, kerr, plasma, thg, pol,
 end
 
 function makeplasma!(out, grid, gas, plasma::Bool, pol,
-                     PPT_options)
+                     PPT_options, preionfrac)
     # simple true/false => default to PPT for atoms, ADK for molecules
     if ~plasma
         return
@@ -550,11 +552,11 @@ function makeplasma!(out, grid, gas, plasma::Bool, pol,
         @info("Using PPT ionisation rate.")
         model = :PPT
     end
-    makeplasma!(out, grid, gas, model, pol, PPT_options)
+    makeplasma!(out, grid, gas, model, pol, PPT_options, preionfrac)
 end
 
 function makeplasma!(out, grid, gas, plasma::Symbol, pol,
-                     PPT_options)
+                     PPT_options, preionfrac)
     ionpot = PhysData.ionisation_potential(gas)
     if plasma == :ADK
         ionrate = Ionisation.ionrate_fun!_ADK(gas)
@@ -565,7 +567,7 @@ function makeplasma!(out, grid, gas, plasma::Symbol, pol,
         throw(DomainError(plasma, "Unknown ionisation rate $plasma."))
     end
     Et = pol ? Array{Float64}(undef, length(grid.to), 2) : grid.to
-    push!(out, Nonlinear.PlasmaCumtrapz(grid.to, Et, ionrate, ionpot))
+    push!(out, Nonlinear.PlasmaCumtrapz(grid.to, Et, ionrate, ionpot, preionfrac))
 end
 
 function makeresponse(grid::Grid.EnvGrid, gas, raman, kerr, plasma, thg, pol,

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -571,7 +571,7 @@ function makeplasma!(out, grid, gas, plasma::Symbol, pol,
 end
 
 function makeresponse(grid::Grid.EnvGrid, gas, raman, kerr, plasma, thg, pol,
-                      rotation, vibration, PPT_options)
+                      rotation, vibration, PPT_options, preionfrac)
     plasma && error("Plasma response for envelope fields has not been implemented yet.")
     isnothing(thg) && (thg = false) 
     out = Any[]

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -567,7 +567,7 @@ function makeplasma!(out, grid, gas, plasma::Symbol, pol,
         throw(DomainError(plasma, "Unknown ionisation rate $plasma."))
     end
     Et = pol ? Array{Float64}(undef, length(grid.to), 2) : grid.to
-    push!(out, Nonlinear.PlasmaCumtrapz(grid.to, Et, ionrate, ionpot, preionfrac))
+    push!(out, Nonlinear.PlasmaCumtrapz(grid.to, Et, ionrate, ionpot; preionfrac))
 end
 
 function makeresponse(grid::Grid.EnvGrid, gas, raman, kerr, plasma, thg, pol,

--- a/src/Nonlinear.jl
+++ b/src/Nonlinear.jl
@@ -121,7 +121,7 @@ end
 function PlasmaScalar!(Plas::PlasmaCumtrapz, E)
     Plas.ratefunc(Plas.rate, E)
     Maths.cumtrapz!(Plas.fraction, Plas.rate, Plas.δt)
-    @. Plas.fraction = (1 - Plas.preionfrac) - exp(-Plas.fraction)
+    @. Plas.fraction = Plas.preionfrac + 1 - exp(-Plas.fraction)
     @. Plas.phase = Plas.fraction * e_ratio * E
     Maths.cumtrapz!(Plas.J, Plas.phase, Plas.δt)
     for ii in eachindex(E)
@@ -147,7 +147,7 @@ function PlasmaVector!(Plas::PlasmaCumtrapz, E)
     Em = @. hypot.(Ex, Ey)
     Plas.ratefunc(Plas.rate, Em)
     Maths.cumtrapz!(Plas.fraction, Plas.rate, Plas.δt)
-    @. Plas.fraction = (1 - Plas.preionfrac) - exp(-Plas.fraction)
+    @. Plas.fraction = Plas.preionfrac + 1 - exp(-Plas.fraction)
     @. Plas.phase = Plas.fraction * e_ratio * E
     Maths.cumtrapz!(Plas.J, Plas.phase, Plas.δt)
     for ii in eachindex(Em)

--- a/src/Nonlinear.jl
+++ b/src/Nonlinear.jl
@@ -110,7 +110,7 @@ function PlasmaCumtrapz(t, E, ratefunc, ionpot; preionfrac=0.0)
     phase = similar(E)
     J = similar(E)
     P = similar(E)
-    !(0.0 <= pre <= 1.0) && throw(DomainError(preionfrac, "preionfrac must be between 0 and 1"))
+    !(0.0 <= preionfrac <= 1.0) && throw(DomainError(preionfrac, "preionfrac must be between 0 and 1"))
     return PlasmaCumtrapz(ratefunc, ionpot, rate, fraction, phase, J, P, t[2]-t[1], preionfrac)
 end
 

--- a/src/Nonlinear.jl
+++ b/src/Nonlinear.jl
@@ -111,6 +111,9 @@ function PlasmaCumtrapz(t, E, ratefunc, ionpot; preionfrac=0.0)
     J = similar(E)
     P = similar(E)
     !(0.0 <= preionfrac <= 1.0) && throw(DomainError(preionfrac, "preionfrac must be between 0 and 1"))
+    if preionfrac > 0.0
+        @warn("Using preionfrac > 0.0 is not a well founded physical model. Use only after careful consideration.")
+    end
     return PlasmaCumtrapz(ratefunc, ionpot, rate, fraction, phase, J, P, t[2]-t[1], preionfrac)
 end
 

--- a/test/test_ionisation.jl
+++ b/test/test_ionisation.jl
@@ -1,4 +1,4 @@
-import Test: @test, @testset
+import Test: @test, @testset, @test_throws
 using Luna
 import NumericalIntegration: integrate, SimpsonEven
 import Logging: with_logger, NullLogger
@@ -122,4 +122,13 @@ end
 
     @test ir2.cspl.x == ir.cspl.x
     @test ir2.cspl.y == ir.cspl.y
+end
+
+@testset "preionisation" begin
+    @test_throws DomainError prop_capillary(265e-6, 0.01, :He, 0.1;
+                                            λ0=800e-9, trange=70e-15, λlims=(100e-9,6e-6),
+                                            τfwhm=6e-15, energy=1.5e-3, preionfrac=1.01)
+    @test_throws DomainError prop_capillary(265e-6, 0.01, :He, 0.1;
+                                            λ0=800e-9, trange=70e-15, λlims=(100e-9,6e-6),
+                                            τfwhm=6e-15, energy=1.5e-3, preionfrac=-0.001)
 end


### PR DESCRIPTION
Add a simple option to include preionisation of the filing gas. This applies a uniform preionisation independent of radial position or field strength. As this is a rather crude and simple approach it is guarded behind a runtime warning and the documentation calls this out. However, this is useful for a quick look at the effect of pre-existing plasma inside the fibre.