### PR TITLE
update run_tests to include lts and pre

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1.9', '1']
+        julia-version: ['lts', '1', 'pre']
         julia-arch: [x64]
         os: [ubuntu-latest, windows-latest, macos-latest]
     if: github.event.pull_request.draft == false


### PR DESCRIPTION
Tentative PR to test with the LTS julia version and the "pre" version, as well as the latest 1 version. Main idea to give a head-up about coming problems and performance, while keeping an eye on LTS which I suppose most people use.