### PR TITLE
Refactor Ionisation module

### DIFF
--- a/examples/low_level_interface/MI_modeAvg_env.jl
+++ b/examples/low_level_interface/MI_modeAvg_env.jl
@@ -26,7 +26,7 @@ linop, βfun!, frame_vel, αfun = LinearOps.make_const_linop(grid, m, λ0)
 
 
 ionpot = PhysData.ionisation_potential(gas)
-ionrate = Ionisation.ionrate_fun!_ADK(ionpot)
+ionrate = Ionisation.IonRateADK(ionpot)
 
 responses = (Nonlinear.Kerr_env(PhysData.γ3_gas(gas)),)
             # Nonlinear.PlasmaCumtrapz(grid.to, grid.to, ionrate, ionpot))

--- a/examples/low_level_interface/SFA_gauss.jl
+++ b/examples/low_level_interface/SFA_gauss.jl
@@ -14,7 +14,7 @@ grid = Grid.RealGrid(0, λ0, (10e-9, 1500e-9), 4*τfwhm)
 It = Maths.gauss.(grid.t; fwhm=τfwhm) .* Ipeak
 Et = Tools.intensity_to_field.(It) .* cos.(grid.t .* wlfreq(λ0))
 
-irf! = Ionisation.ionrate_fun!_PPTcached(gas, λ0)
+irf! = Ionisation.IonRatePPTCached(gas, λ0)
 
 D = SFA.sfa_dipole(grid.t, Et, gas, λ0; gate=true, depletion=true, irf!)
 eV = PhysData.ħ .* grid.ω ./ PhysData.electron
@@ -24,7 +24,7 @@ gab = Maths.gabor(grid.t, D, tg, 300e-18)
 ##
 IpeV = PhysData.ionisation_potential(gas; unit=:eV)
 # Ponderomotive energy:
-Up = PhysData.electron^2 * maximum(Et)^2/(4*PhysData.m_e * wlfreq(λ0)^2) 
+Up = PhysData.electron^2 * maximum(Et)^2/(4*PhysData.m_e * wlfreq(λ0)^2)
 UpeV = Up/PhysData.electron
 # Cutoff law:
 cutoffeV = IpeV + 3.17UpeV
@@ -52,4 +52,3 @@ cb = plt.colorbar()
 cb.set_label("Log10 SED")
 plt.xlabel("Time (fs)")
 plt.ylabel("Photon energy (eV)")
-

--- a/examples/low_level_interface/arpcf_modeAvg.jl
+++ b/examples/low_level_interface/arpcf_modeAvg.jl
@@ -23,7 +23,7 @@ densityfun = let dens0=PhysData.density(gas, pres)
 end
 
 ionpot = PhysData.ionisation_potential(gas)
-ionrate = Ionisation.ionrate_fun!_ADK(ionpot)
+ionrate = Ionisation.IonRateADK(ionpot)
 
 plasma = Nonlinear.PlasmaCumtrapz(grid.to, grid.to, ionrate, ionpot)
 responses = (Nonlinear.Kerr_field(PhysData.γ3_gas(gas)),

--- a/examples/low_level_interface/basic_modal.jl
+++ b/examples/low_level_interface/basic_modal.jl
@@ -23,7 +23,7 @@ densityfun = let dens0=PhysData.density(gas, pres)
 end
 
 ionpot = PhysData.ionisation_potential(gas)
-ionrate = Ionisation.ionrate_fun!_PPTcached(gas, λ0)
+ionrate = Ionisation.IonRatePPTCached(gas, λ0)
 
 responses = (Nonlinear.Kerr_field(PhysData.γ3_gas(gas)),
              Nonlinear.PlasmaCumtrapz(grid.to, grid.to, ionrate, ionpot))
@@ -31,7 +31,7 @@ responses = (Nonlinear.Kerr_field(PhysData.γ3_gas(gas)),
 inputs = Fields.GaussField(λ0=λ0, τfwhm=τfwhm, energy=energy)
 
 Eω, transform, FT = Luna.setup(grid, densityfun, responses, inputs, modes, :y; full=false)
-                              
+
 linop = LinearOps.make_const_linop(grid, modes, λ0)
 
 statsfun = Stats.default(grid, Eω, modes, linop, transform; gas=gas, windows=((150e-9, 300e-9),))
@@ -48,4 +48,3 @@ Plotting.time_1D(output, [5e-2, 9.8e-2])
 Plotting.time_1D(output, [5e-2, 9e-2], modes=:sum, bandpass=(150e-9, 300e-9))
 Plotting.spec_1D(output, [5e-2, 9.8e-2])
 Plotting.spec_1D(output, [5e-2, 9.8e-2], modes=:sum)
-

--- a/examples/low_level_interface/basic_modal_env.jl
+++ b/examples/low_level_interface/basic_modal_env.jl
@@ -24,7 +24,7 @@ densityfun = let dens0=PhysData.density(gas, pres)
 end
 
 ionpot = PhysData.ionisation_potential(gas)
-ionrate = Ionisation.ionrate_fun!_ADK(ionpot)
+ionrate = Ionisation.IonRateADK(ionpot)
 
 responses = (Nonlinear.Kerr_env(PhysData.γ3_gas(gas)),)
              #Nonlinear.PlasmaCumtrapz(grid.to, grid.to, ionrate, ionpot))

--- a/examples/low_level_interface/basic_modeAvg.jl
+++ b/examples/low_level_interface/basic_modeAvg.jl
@@ -21,7 +21,7 @@ densityfun = let dens0=PhysData.density(gas, pres)
 end
 
 ionpot = PhysData.ionisation_potential(gas)
-ionrate = Ionisation.ionrate_fun!_ADK(ionpot)
+ionrate = Ionisation.IonRateADK(ionpot)
 
 plasma = Nonlinear.PlasmaCumtrapz(grid.to, grid.to, ionrate, ionpot)
 responses = (Nonlinear.Kerr_field(PhysData.γ3_gas(gas)),

--- a/examples/low_level_interface/basic_modeAvg_field_noTHG.jl
+++ b/examples/low_level_interface/basic_modeAvg_field_noTHG.jl
@@ -26,7 +26,7 @@ linop, βfun!, frame_vel, αfun = LinearOps.make_const_linop(grid, m, λ0)
 
 
 ionpot = PhysData.ionisation_potential(gas)
-ionrate = Ionisation.ionrate_fun!_ADK(ionpot)
+ionrate = Ionisation.IonRateADK(ionpot)
 
 responses = (Nonlinear.Kerr_field_nothg(PhysData.γ3_gas(gas),length(grid.to)),
              Nonlinear.PlasmaCumtrapz(grid.to, grid.to, ionrate, ionpot))

--- a/examples/low_level_interface/freespace/full3D.jl
+++ b/examples/low_level_interface/freespace/full3D.jl
@@ -29,7 +29,7 @@ densityfun = let dens0=PhysData.density(gas, pres)
 end
 
 ionpot = PhysData.ionisation_potential(gas)
-ionrate = Ionisation.ionrate_fun!_ADK(ionpot)
+ionrate = Ionisation.IonRateADK(ionpot)
 responses = (Nonlinear.Kerr_field(PhysData.γ3_gas(gas)),)
 #  Nonlinear.PlasmaCumtrapz(grid.to, grid.to, ionrate, ionpot))
 

--- a/examples/low_level_interface/freespace/radial.jl
+++ b/examples/low_level_interface/freespace/radial.jl
@@ -27,7 +27,7 @@ densityfun = let dens0=PhysData.density(gas, pres)
 end
 
 ionpot = PhysData.ionisation_potential(gas)
-ionrate = Ionisation.ionrate_fun!_PPTcached(gas, λ0)
+ionrate = Ionisation.IonRatePPTCached(gas, λ0)
 
 responses = (Nonlinear.Kerr_field(PhysData.γ3_gas(gas)),)
              #Nonlinear.PlasmaCumtrapz(grid.to, grid.to, ionrate, ionpot))

--- a/examples/low_level_interface/freespace/radial_hcf.jl
+++ b/examples/low_level_interface/freespace/radial_hcf.jl
@@ -28,7 +28,7 @@ densityfun = let dens0=PhysData.density(gas, pres)
 end
 
 ionpot = PhysData.ionisation_potential(gas)
-ionrate = Ionisation.ionrate_fun!_PPTcached(gas, λ0)
+ionrate = Ionisation.IonRatePPTCached(gas, λ0)
 
 responses = (Nonlinear.Kerr_field(PhysData.γ3_gas(gas)),)
              #Nonlinear.PlasmaCumtrapz(grid.to, grid.to, ionrate, ionpot))

--- a/examples/low_level_interface/full_modal/basic_modal_full.jl
+++ b/examples/low_level_interface/full_modal/basic_modal_full.jl
@@ -25,7 +25,7 @@ densityfun = let dens0=PhysData.density(gas, pres)
 end
 
 ionpot = PhysData.ionisation_potential(gas)
-ionrate = Ionisation.ionrate_fun!_ADK(ionpot)
+ionrate = Ionisation.IonRateADK(ionpot)
 
 responses = (Nonlinear.Kerr_field(PhysData.γ3_gas(gas)),
              Nonlinear.PlasmaCumtrapz(grid.to, grid.to, ionrate, ionpot))

--- a/examples/low_level_interface/full_modal/basic_modal_full_bothpolarisations.jl
+++ b/examples/low_level_interface/full_modal/basic_modal_full_bothpolarisations.jl
@@ -25,7 +25,7 @@ densityfun = let dens0=PhysData.density(gas, pres)
 end
 
 ionpot = PhysData.ionisation_potential(gas)
-ionrate = Ionisation.ionrate_fun!_ADK(ionpot)
+ionrate = Ionisation.IonRateADK(ionpot)
 
 responses = (Nonlinear.Kerr_field(PhysData.γ3_gas(gas)),
              Nonlinear.PlasmaCumtrapz(grid.to, grid.to, ionrate, ionpot))
@@ -34,7 +34,7 @@ inputs = Fields.GaussField(λ0=λ0, τfwhm=τfwhm, energy=energy)
 
 Eω, transform, FT = Luna.setup(grid, densityfun, responses, inputs, modes,
                                :xy; full=true)
-                 
+
 statsfun = Stats.default(grid, Eω, modes, linop, transform; gas=gas, windows=((150e-9, 300e-9),))
 output = Output.MemoryOutput(0, grid.zmax, 201, statsfun)
 linop = LinearOps.make_const_linop(grid, modes, λ0)

--- a/examples/low_level_interface/gradients/gradient_modal.jl
+++ b/examples/low_level_interface/gradients/gradient_modal.jl
@@ -22,7 +22,7 @@ grid = Grid.RealGrid(L, λ0, (160e-9, 3000e-9), 1e-12)
 energyfun, energyfunω = Fields.energyfuncs(grid)
 
 ionpot = PhysData.ionisation_potential(gas)
-ionrate = Ionisation.ionrate_fun!_ADK(ionpot)
+ionrate = Ionisation.IonRateADK(ionpot)
 
 responses = (Nonlinear.Kerr_field(PhysData.γ3_gas(gas)),)
              #Nonlinear.PlasmaCumtrapz(grid.to, grid.to, ionrate, ionpot))

--- a/examples/low_level_interface/gradients/gradient_modeAvg.jl
+++ b/examples/low_level_interface/gradients/gradient_modeAvg.jl
@@ -21,7 +21,7 @@ end
 energyfun, energyfunω = Fields.energyfuncs(grid)
 
 ionpot = PhysData.ionisation_potential(gas)
-ionrate = Ionisation.ionrate_fun!_ADK(ionpot)
+ionrate = Ionisation.IonRateADK(ionpot)
 
 responses = (Nonlinear.Kerr_field(PhysData.γ3_gas(gas)),
              Nonlinear.PlasmaCumtrapz(grid.to, grid.to, ionrate, ionpot))

--- a/examples/low_level_interface/gradients/gradient_modeAvg_env.jl
+++ b/examples/low_level_interface/gradients/gradient_modeAvg_env.jl
@@ -21,7 +21,7 @@ end
 energyfun, energyfunω = Fields.energyfuncs(grid)
 
 ionpot = PhysData.ionisation_potential(gas)
-ionrate = Ionisation.ionrate_fun!_ADK(ionpot)
+ionrate = Ionisation.IonRateADK(ionpot)
 
 responses = (Nonlinear.Kerr_env(PhysData.γ3_gas(gas)),)
 

--- a/examples/low_level_interface/mixtures/mixture_modeAvg.jl
+++ b/examples/low_level_interface/mixtures/mixture_modeAvg.jl
@@ -21,7 +21,7 @@ densityfun = let dens0=PhysData.density(gas, pres/2)
 end
 
 ionpot = PhysData.ionisation_potential(gas)
-ionrate = Ionisation.ionrate_fun!_ADK(ionpot)
+ionrate = Ionisation.IonRateADK(ionpot)
 
 responses = ((Nonlinear.Kerr_field(PhysData.γ3_gas(gas)),
              Nonlinear.PlasmaCumtrapz(grid.to, grid.to, ionrate, ionpot)),

--- a/examples/low_level_interface/plasma_ssfbs_modeAvg.jl
+++ b/examples/low_level_interface/plasma_ssfbs_modeAvg.jl
@@ -22,7 +22,7 @@ dens0 = PhysData.density(gas, pres)
 densityfun(z) = dens0
 
 ionpot = PhysData.ionisation_potential(gas)
-ionrate = Ionisation.ionrate_fun!_ADK(ionpot)
+ionrate = Ionisation.IonRateADK(ionpot)
 
 plasma = Nonlinear.PlasmaCumtrapz(grid.to, grid.to, ionrate, ionpot)
 responses = (Nonlinear.Kerr_field(PhysData.γ3_gas(gas)),

--- a/examples/low_level_interface/polarisation/elliptical.jl
+++ b/examples/low_level_interface/polarisation/elliptical.jl
@@ -51,7 +51,7 @@ densityfun = let dens0=PhysData.density(gas, pres)
 end
 
 ionpot = PhysData.ionisation_potential(gas)
-ionrate = Ionisation.ionrate_fun!_ADK(ionpot)
+ionrate = Ionisation.IonRateADK(ionpot)
 
 responses = (Nonlinear.Kerr_field(PhysData.γ3_gas(gas)),)
              #Nonlinear.PlasmaCumtrapz(grid.to, grid.to, ionrate, ionpot))
@@ -169,5 +169,3 @@ plt.plot(zout, Ss[3,:], label="S3")
 plt.plot(zout, Ss[4,:], label="S4")
 plt.plot(zout, Elipt, label="ε")
 plt.legend()
-
-

--- a/examples/low_level_interface/polarisation/modal_nonvector_plasma.jl
+++ b/examples/low_level_interface/polarisation/modal_nonvector_plasma.jl
@@ -22,10 +22,10 @@ dens0 = PhysData.density(gas, pres)
 densityfun(z) = dens0
 
 ionpot = PhysData.ionisation_potential(gas)
-ionrate = Ionisation.ionrate_fun!_ADK(ionpot)
+ionrate = Ionisation.IonRateADK(ionpot)
 plasma = Nonlinear.PlasmaCumtrapz(grid.to, grid.to,
                                   ionrate, ionpot)
-                                  
+
 responses = (Nonlinear.Kerr_field(PhysData.γ3_gas(gas)),
              plasma)
 
@@ -43,4 +43,3 @@ Luna.run(Eω, grid, linop, transform, FT, output)
 Plotting.pygui(true)
 Plotting.stats(output)
 Plotting.prop_2D(output, :λ, λrange=(500e-9,1800e-9), trange=(-500e-15,100e-15), dBmin=-30.0)
-

--- a/examples/low_level_interface/polarisation/modal_vector_plasma.jl
+++ b/examples/low_level_interface/polarisation/modal_vector_plasma.jl
@@ -22,10 +22,10 @@ dens0 = PhysData.density(gas, pres)
 densityfun(z) = dens0
 
 ionpot = PhysData.ionisation_potential(gas)
-ionrate = Ionisation.ionrate_fun!_ADK(ionpot)
+ionrate = Ionisation.IonRateADK(ionpot)
 plasma = Nonlinear.PlasmaCumtrapz(grid.to, Array{Float64}(undef, length(grid.to), 2),
                                   ionrate, ionpot)
-                                  
+
 responses = (Nonlinear.Kerr_field(PhysData.γ3_gas(gas)),
              plasma)
 
@@ -43,4 +43,3 @@ Luna.run(Eω, grid, linop, transform, FT, output)
 Plotting.pygui(true)
 Plotting.stats(output)
 Plotting.prop_2D(output, :λ, λrange=(500e-9,1800e-9), trange=(-500e-15,100e-15), dBmin=-30.0)
-

--- a/examples/low_level_interface/polarisation/modal_vector_plasma_45deg.jl
+++ b/examples/low_level_interface/polarisation/modal_vector_plasma_45deg.jl
@@ -23,10 +23,10 @@ dens0 = PhysData.density(gas, pres)
 densityfun(z) = dens0
 
 ionpot = PhysData.ionisation_potential(gas)
-ionrate = Ionisation.ionrate_fun!_ADK(ionpot)
+ionrate = Ionisation.IonRateADK(ionpot)
 plasma = Nonlinear.PlasmaCumtrapz(grid.to, Array{Float64}(undef, length(grid.to), 2),
                                   ionrate, ionpot)
-                                  
+
 responses = (Nonlinear.Kerr_field(PhysData.γ3_gas(gas)),
              plasma)
 

--- a/examples/low_level_interface/polarisation/modal_vector_plasma_CP.jl
+++ b/examples/low_level_interface/polarisation/modal_vector_plasma_CP.jl
@@ -23,10 +23,10 @@ dens0 = PhysData.density(gas, pres)
 densityfun(z) = dens0
 
 ionpot = PhysData.ionisation_potential(gas)
-ionrate = Ionisation.ionrate_fun!_ADK(ionpot)
+ionrate = Ionisation.IonRateADK(ionpot)
 plasma = Nonlinear.PlasmaCumtrapz(grid.to, Array{Float64}(undef, length(grid.to), 2),
                                   ionrate, ionpot)
-                                  
+
 responses = (Nonlinear.Kerr_field(PhysData.γ3_gas(gas)),
              plasma)
 

--- a/examples/low_level_interface/rectangular/rectangular_modal.jl
+++ b/examples/low_level_interface/rectangular/rectangular_modal.jl
@@ -20,7 +20,7 @@ densityfun = let dens0=PhysData.density(gas, pres)
 end
 
 ionpot = PhysData.ionisation_potential(gas)
-ionrate = Ionisation.ionrate_fun!_ADK(ionpot)
+ionrate = Ionisation.IonRateADK(ionpot)
 
 responses = (Nonlinear.Kerr_field(PhysData.γ3_gas(gas)),)
              #Nonlinear.PlasmaCumtrapz(grid.to, grid.to, ionrate, ionpot))

--- a/examples/low_level_interface/rectangular/rectangular_modeAvg.jl
+++ b/examples/low_level_interface/rectangular/rectangular_modeAvg.jl
@@ -22,7 +22,7 @@ densityfun = let dens0=PhysData.density(gas, pres)
 end
 
 ionpot = PhysData.ionisation_potential(gas)
-ionrate = Ionisation.ionrate_fun!_ADK(ionpot)
+ionrate = Ionisation.IonRateADK(ionpot)
 
 responses = (Nonlinear.Kerr_field(PhysData.γ3_gas(gas)),
              Nonlinear.PlasmaCumtrapz(grid.to, grid.to, ionrate, ionpot))

--- a/examples/low_level_interface/rectangular/rectangular_modeAvg_env.jl
+++ b/examples/low_level_interface/rectangular/rectangular_modeAvg_env.jl
@@ -4,7 +4,7 @@ a = 50e-6
 b = 10e-6
 gas = :Ar
 pres = 5
-L = 15e-2 
+L = 15e-2
 
 τfwhm = 30e-15
 λ0 = 800e-9
@@ -22,7 +22,7 @@ densityfun = let dens0=PhysData.density(gas, pres)
 end
 
 ionpot = PhysData.ionisation_potential(gas)
-ionrate = Ionisation.ionrate_fun!_ADK(ionpot)
+ionrate = Ionisation.IonRateADK(ionpot)
 
 responses = (Nonlinear.Kerr_env(PhysData.γ3_gas(gas)),)
              #Nonlinear.PlasmaCumtrapz(grid.to, grid.to, ionrate, ionpot))

--- a/examples/low_level_interface/tapers/taper_modal.jl
+++ b/examples/low_level_interface/tapers/taper_modal.jl
@@ -29,7 +29,7 @@ densityfun = let dens0=PhysData.density(gas, pres)
 end
 
 ionpot = PhysData.ionisation_potential(gas)
-ionrate = Ionisation.ionrate_fun!_ADK(ionpot)
+ionrate = Ionisation.IonRateADK(ionpot)
 
 responses = (Nonlinear.Kerr_field(PhysData.γ3_gas(gas)),)
             #  Nonlinear.PlasmaCumtrapz(grid.to, grid.to, ionrate, ionpot))

--- a/examples/low_level_interface/tapers/taper_modeAvg.jl
+++ b/examples/low_level_interface/tapers/taper_modeAvg.jl
@@ -20,7 +20,7 @@ afun = let a0=a0, aL=aL, L=L
 end
 # coren, dens = Capillary.gradient(gas, L, pres, pres); # dens is unused
 m = Capillary.MarcatiliMode(afun, gas, pres, loss=false, model=:full);
- 
+
 aeff(z) = Modes.Aeff(m, z=z)
 
 densityfun = let dens0=PhysData.density(gas, pres)
@@ -28,7 +28,7 @@ densityfun = let dens0=PhysData.density(gas, pres)
 end
 
 ionpot = PhysData.ionisation_potential(gas)
-ionrate = Ionisation.ionrate_fun!_ADK(ionpot)
+ionrate = Ionisation.IonRateADK(ionpot)
 
 responses = (Nonlinear.Kerr_field(PhysData.γ3_gas(gas)),
              Nonlinear.PlasmaCumtrapz(grid.to, grid.to, ionrate, ionpot))

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -316,7 +316,7 @@ In this case, all keyword arguments except for `λ0` are ignored.
     Note that plasma is only available for full-field simulations.
 - `PPT_options::Dict{Symbol, Any}`: when using the PPT ionisation rate for the
     plasma nonlinearity, this allows for fine-tuning of the options in calculating
-    the ionisation. See [`ionrate_fun_PPT`](@ref Ionisation.ionrate_fun_PPT) for possible
+    the ionisation. See [`IonRatePPTAccel`](@ref Ionisation.IonRatePPTAccel) for possible
     keyword arguments.
 - `preionfrac::Float64`: fraction of the gas that is pre-ionised before the pulse. Defaults to `0.0`.
     Note that this is a very simplistic model of pre-ionisation and should be used with

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -578,9 +578,9 @@ function makeplasma!(out, grid, gas, plasma::Symbol, pol,
                      PPT_options, preionfrac)
     ionpot = PhysData.ionisation_potential(gas)
     if plasma == :ADK
-        ionrate = Ionisation.ionrate_fun!_ADK(gas)
+        ionrate = Ionisation.IonRateADK(gas)
     elseif plasma == :PPT
-        ionrate = Ionisation.ionrate_fun!_PPTcached(gas, grid.referenceλ;
+        ionrate = Ionisation.IonRatePPTCached(gas, grid.referenceλ;
                                                     PPT_options...)
     else
         throw(DomainError(plasma, "Unknown ionisation rate $plasma."))

--- a/src/Ionisation.jl
+++ b/src/Ionisation.jl
@@ -194,11 +194,11 @@ function IonRatePPT(ip, λ0, Z, l; Δα=0, α_ion=0, sum_tol=1e-6,
     cycle_average=false, sum_integral=false, msum=true, Cnl=missing, occupancy=2)
 
     if ismissing(Δα)
-        Δα = 0
+        Δα = 0.0
     end
 
     if ismissing(α_ion)
-        α_ion = 0
+        α_ion = 0.0
     end
 
     α_ion_au = α_ion/au_polarisability
@@ -435,7 +435,7 @@ function makePPTcache(ionpot::Float64, λ0, Z, l;
     Emin = Emax/5000
 
     E = collect(range(Emin, stop=Emax, length=N));
-    @info @sprintf("Pre-calculating PPT rate rate for %.2f eV, %.1f nm...", ionpot/electron, 1e9λ0)
+    @info @sprintf("Pre-calculating PPT rate for %.2f eV, %.1f nm...", ionpot/electron, 1e9λ0)
     flush(stderr) # pre-calculating can take a while, so make sure this message is shown
     rate = ionrate_PPT(ionpot, λ0, Z, l, E; kwargs...)
     @info "...PPT pre-calcuation done"

--- a/src/Ionisation.jl
+++ b/src/Ionisation.jl
@@ -157,7 +157,7 @@ Physics Reports 441(2–4), 47–189 (2007).
 
 """
 struct IonRatePPT{oT, CT} <: AbstractIonRate
-    Z::Int # Charge state
+    Z::Float64 # Charge state
     l::Int # Orbital angular momentum quantum number
     Δα::Float64 # Polarisbility difference between ground state and ion
     α_ion_au::Float64 # Polarisbility of the ion in atomic units
@@ -187,7 +187,7 @@ function IonRatePPT(material::Symbol, λ0; stark_shift=true, dipole_corr=true, k
     Δα = stark_shift ? polarisability_difference(material) : 0.0
     α_ion = dipole_corr ? polarisability(material, true) : 0.0
     ip = ionisation_potential(material)
-    IonRatePPT(ip, λ0, Z, l; Δα, α_ion, kwargs...)
+    IonRatePPT(ip, λ0, float(Z), l; Δα, α_ion, kwargs...)
 end
 
 function IonRatePPT(ip, λ0, Z, l; Δα=0, α_ion=0, sum_tol=1e-6,
@@ -206,7 +206,7 @@ function IonRatePPT(ip, λ0, Z, l; Δα=0, α_ion=0, sum_tol=1e-6,
     ω0 = 2π*c/λ0
     ω0_au = au_time*ω0
 
-    IonRatePPT(Z, l, Δα, α_ion_au, ω0_au, Cnl, ip, occupancy,
+    IonRatePPT(float(Z), l, Δα, α_ion_au, ω0_au, Cnl, ip, occupancy,
         msum, sum_integral, sum_tol, cycle_average)
 end
 

--- a/src/Ionisation.jl
+++ b/src/Ionisation.jl
@@ -184,8 +184,8 @@ Other keyword arguments are identical to `IonRatePPT(ionpot::Float64, λ0, Z, l;
 """
 function IonRatePPT(material::Symbol, λ0; stark_shift=true, dipole_corr=true, kwargs...)
     _, l, Z = quantum_numbers(material)
-    Δα = stark_shift ? polarisability_difference(material) : 0
-    α_ion = dipole_corr ? polarisability(material, true) : 0
+    Δα = stark_shift ? polarisability_difference(material) : 0.0
+    α_ion = dipole_corr ? polarisability(material, true) : 0.0
     ip = ionisation_potential(material)
     IonRatePPT(ip, λ0, Z, l; Δα, α_ion, kwargs...)
 end
@@ -317,8 +317,8 @@ end
 function ionrate_PPT(material::Symbol, λ0, E;
                      stark_shift=true, dipole_corr=true, kwargs...)
     _, l, Z = quantum_numbers(material)
-    Δα = stark_shift ? polarisability_difference(material) : 0
-    α_ion = dipole_corr ? polarisability(material, true) : 0
+    Δα = stark_shift ? polarisability_difference(material) : 0.0
+    α_ion = dipole_corr ? polarisability(material, true) : 0.0
     ip = ionisation_potential(material)
     return ionrate_PPT(ip, λ0, Z, l, E; Δα, α_ion, kwargs...)
 end
@@ -361,8 +361,8 @@ end
 
 function IonRatePPTAccel(material::Symbol, λ0; stark_shift=true, dipole_corr=true, kwargs...)
     _, l, Z = quantum_numbers(material)
-    Δα = stark_shift ? polarisability_difference(material) : 0
-    α_ion = dipole_corr ? polarisability(material, true) : 0
+    Δα = stark_shift ? polarisability_difference(material) : 0.0
+    α_ion = dipole_corr ? polarisability(material, true) : 0.0
     ip = ionisation_potential(material)
     IonRatePPTAccel(ip, λ0, Z, l; Δα, α_ion, kwargs...)
 end

--- a/src/Ionisation.jl
+++ b/src/Ionisation.jl
@@ -10,16 +10,34 @@ import Luna.PhysData: ionisation_potential, quantum_numbers
 import Luna: Maths, Utils
 import Printf: @sprintf
 
-"""
-    ionrate_fun!_ADK(ionpot::Float64, threshold=true)
-    ionrate_fun!_ADK(material::Symbol)
+abstract type AbstractIonRate end
 
-Return a closure `ionrate!(out, E)` which calculates the ADK ionisation rate for the electric
-field `E` and places the result in `out`. If `threshold` is true, use [`ADK_threshold`](@ref)
+"""
+    IonRateADK(ionpot::Float64, threshold=true)
+    IonRateADK(material::Symbol)
+
+Ionisation rate based on the ADK formula. If `threshold` is true, use [`ADK_threshold`](@ref)
 to avoid calculation below floating-point precision. If `cycle_average` is `true`, calculate
 the cycle-averaged ADK ionisation rate instead.
 """
-function ionrate_fun!_ADK(ionpot::Float64, threshold=true; cycle_average=false)
+struct IonRateADK <: AbstractIonRate
+    ionpot::Float64
+    threshold::Bool
+    cycle_average::Bool
+    nstar::Float64
+    cn_sq::Float64
+    ω_p::Float64
+    ω_t_prefac::Float64
+    thr::Float64
+    avfac::Float64
+    occupancy::Int
+end
+
+function IonRateADK(material::Symbol; kwargs...)
+    IonRateADK(ionisation_potential(material); kwargs...)
+end
+
+function IonRateADK(ionpot::Number; occupancy=2, threshold=true, cycle_average=false)
     nstar = sqrt(0.5/(ionpot/au_energy))
     cn_sq = 2^(2*nstar)/(nstar*gamma(nstar+1)*gamma(nstar))
     ω_p = ionpot/ħ
@@ -28,54 +46,60 @@ function ionrate_fun!_ADK(ionpot::Float64, threshold=true; cycle_average=false)
     if threshold
         thr = ADK_threshold(ionpot)
     else
-        thr = 0
+        thr = 0.0
     end
 
-    # Zenghu Chang: Fundamentals of Attosecond Optics (2011) p. 184
-    # Section 4.2.3.1 Cycle-Averaged Rate
-    # ̄w_ADK(Fₐ) = √(3/π) √(Fₐ/F₀) w_ADK(Fₐ) where Fₐ is the field amplitude
-    Ip_au = ionpot / au_energy
-    F0_au = (2Ip_au)^(3/2)
-    F0 = F0_au*au_Efield
-    avfac = sqrt.(3/(π*F0))
-
-
-    ionrate! = let nstar=nstar, cn_sq=cn_sq, ω_p=ω_p, ω_t_prefac=ω_t_prefac, thr=thr
-        function ir(E)
-            if abs(E) >= thr
-                r = (ω_p*cn_sq*
-                    (4*ω_p/(ω_t_prefac*abs(E)))^(2*nstar-1)
-                    *exp(-4/3*ω_p/(ω_t_prefac*abs(E))))
-                if cycle_average
-                    r *= avfac*sqrt(abs(E))
-                end
-                return r
-            else
-                return zero(E)
-            end
-        end
-        function ionrate!(out, E)
-            out .= ir.(E)
-        end
+    if cycle_average
+        # Zenghu Chang: Fundamentals of Attosecond Optics (2011) p. 184
+        # Section 4.2.3.1 Cycle-Averaged Rate
+        # ̄w_ADK(Fₐ) = √(3/π) √(Fₐ/F₀) w_ADK(Fₐ) where Fₐ is the field amplitude
+        Ip_au = ionpot / au_energy
+        F0_au = (2Ip_au)^(3/2)
+        F0 = F0_au*au_Efield
+        avfac = sqrt.(3/(π*F0))
+    else
+        avfac = 1.0
     end
 
-    return ionrate!
+    IonRateADK(ionpot, threshold, cycle_average,
+               nstar, cn_sq, ω_p, ω_t_prefac, thr, avfac, occupancy)
 end
 
-function ionrate_fun!_ADK(material::Symbol; kwargs...)
-    return ionrate_fun!_ADK(ionisation_potential(material); kwargs...)
+function (ir::IonRateADK)(E)
+    aE = abs(E)
+    if aE >= ir.thr
+        r = (ir.occupancy * ir.ω_p * ir.cn_sq *
+             (4 * ir.ω_p / (ir.ω_t_prefac * aE))^(2 * ir.nstar - 1)
+             * exp(-4 / 3 * ir.ω_p / (ir.ω_t_prefac * aE)))
+        if ir.avfac ≠ 1
+            r *= ir.avfac*sqrt(aE)
+        end
+        return r
+    else
+        return zero(E)
+    end
 end
 
+function (ir::IonRateADK)(out::AbstractArray, E::AbstractArray)
+    out .= ir.(E)
+end
+
+"""
+    ionrate_ADK(IP_or_material, E::Number; kwargs...) -> Float64
+
+Calculate the ionisation rate based on the ADK model.
+
+# Arguments
+
+- `IP_or_material`: Ionisation potential (`Float64`) or gas species (`Symbol`)
+- `E::Number`: Electric field in SI units (V/M)
+
+# Keywords
+
+- `kwargs...`: See `IonRateADK`
+"""
 function ionrate_ADK(IP_or_material, E; kwargs...)
-    out = zero(E)
-    ionrate_fun!_ADK(IP_or_material; kwargs...)(out, E)
-    return out
-end
-
-function ionrate_ADK(IP_or_material, E::Number; kwargs...)
-    out = [zero(E)]
-    ionrate_fun!_ADK(IP_or_material; kwargs...)(out, [E])
-    return out[1]
+    IonRateADK(IP_or_material; kwargs...).(E)
 end
 
 """
@@ -85,39 +109,230 @@ Determine the lowest electric field strength at which the ADK ionisation rate fo
 ionisation potential `ionpot` is non-zero to within 64-bit floating-point precision.
 """
 function ADK_threshold(ionpot)
-    out = [0.0]
-    ADKfun = ionrate_fun!_ADK(ionpot, false)
+    ADKfun = IonRateADK(ionpot; threshold=false)
     E = 1e3
-    while out[1] == 0
+    out = ADKfun(E)
+    while out == 0
         E *= 1.01
-        ADKfun(out, [E])
+        out = ADKfun(E)
     end
     return E
 end
 
 """
-    ionrate_fun!_PPTaccel(material::Symbol, λ0; kwargs...)
-    ionrate_fun!_PPTaccel(ionpot::Float64, λ0, Z, l; kwargs...)
+    IonRatePPT(ionpot::Float64, λ0, Z, l; kwargs...)
 
-Create an accelerated (interpolated) PPT ionisation rate function.
+PPT ionisation rate for a state with ionisation potential `ionpot`, when driven at
+wavelength `λ0`, also given charge state `Z` and angular momentum `l`
+
+# Keyword arguments
+- `sum_tol::Number`: Relative tolerance used to truncate the infinite sum. Defaults to 1e-6.
+- `cycle_average::Bool`: If `true`, calculate the cycle-averaged rate. Defaults to `false`.
+- `sum_integral::Bool`: whether to approximate the infinite sum in the PPT rate equation with
+    an integral (this neglects the multiphoton thresholds).
+- `Δα::Number`: polarisability difference between the ground state and the cation (in SI units)
+    to calculate the Stark shift of the ground-state energy levels. Defaults to 0.
+- `α_ion::Number`: polarisability of the cation (in SI units) to calculate the dipole correction
+    to the rate. Defaults to 0.
+- `msum::Bool`: for l ≠ 0, whether or not to sum over different m states. Defaults to `true`.
+- `Cnl::Real` : Pre-calculated `Cₙₗ` constant. If not given, defaults to the approximate expression from
+    the PPT papers.
+- `occupancy`: Occupancy of the state(s) from which ionisation is considered. Defaults to 2 for
+    a state with two electrons (spin up/down).
+
+# References
+[1] Ilkov, F. A., Decker, J. E. & Chin, S. L.
+Ionization of atoms in the tunnelling regime with experimental evidence
+using Hg atoms. Journal of Physics B: Atomic, Molecular and Optical
+Physics 25, 4005–4020 (1992)
+
+[2] Bergé, L., Skupin, S., Nuter, R., Kasparian, J. & Wolf, J.-P.
+Ultrashort filaments of light in weakly ionized, optically transparent
+media. Rep. Prog. Phys. 70, 1633–1713 (2007)
+(Appendix A)
+
+[3] A. Couairon and A. Mysyrowicz,
+"Femtosecond filamentation in transparent media,"
+Physics Reports 441(2–4), 47–189 (2007).
+
 """
-function ionrate_fun!_PPTaccel(material::Symbol, λ0;
-                               stark_shift=true, dipole_corr=true, kwargs...)
+struct IonRatePPT{oT, CT} <: AbstractIonRate
+    Z::Int # Charge state
+    l::Int # Orbital angular momentum quantum number
+    Δα::Float64 # Polarisbility difference between ground state and ion
+    α_ion_au::Float64 # Polarisbility of the ion in atomic units
+    ω0_au::Float64 # central frequency in atomic units
+    Cnl::CT # either missing (default) or a pre-defined value for Cₙₗ
+    ionpot::Float64 # ionisation potential in SI units
+    occupancy::oT # occupancy (integer) or function occ(m) returning occupancy in m level
+    msum::Bool # sum over m levels?
+    sum_integral::Bool # replace the infinite sum with an integral?
+    sum_tol::Float64 # relative tolerance for convergence of the infinite sum
+    cycle_average::Bool # average over one cycle?
+end
+
+"""
+    IonRatePPT(material::Symbol, λ0; kwargs...)
+
+PPT ionisation rate for the given `material` when driven at wavelength `λ0`.
+
+# Keyword arguments
+- `stark_shift::Bool`: whether to include the Stark shift
+- `dipole_corr::Bool`: whether to include the dipole correction factor
+
+Other keyword arguments are identical to `IonRatePPT(ionpot::Float64, λ0, Z, l; kwargs...)`
+"""
+function IonRatePPT(material::Symbol, λ0; stark_shift=true, dipole_corr=true, kwargs...)
     _, l, Z = quantum_numbers(material)
-    ip = ionisation_potential(material)
     Δα = stark_shift ? polarisability_difference(material) : 0
     α_ion = dipole_corr ? polarisability(material, true) : 0
-    ionrate_fun!_PPTaccel(ip, λ0, Z, l; Δα, α_ion, kwargs...)
+    ip = ionisation_potential(material)
+    IonRatePPT(ip, λ0, Z, l; Δα, α_ion, kwargs...)
 end
 
-function ionrate_fun!_PPTaccel(ionpot::Float64, λ0, Z, l; kwargs...)
-    E, rate = makePPTcache(ionpot, λ0, Z, l; kwargs...)
-    return makePPTaccel(E, rate)
+function IonRatePPT(ip, λ0, Z, l; Δα=0, α_ion=0, sum_tol=1e-6,
+    cycle_average=false, sum_integral=false, msum=true, Cnl=missing, occupancy=2)
+
+    if ismissing(Δα)
+        Δα = 0
+    end
+
+    if ismissing(α_ion)
+        α_ion = 0
+    end
+
+    α_ion_au = α_ion/au_polarisability
+
+    ω0 = 2π*c/λ0
+    ω0_au = au_time*ω0
+
+    IonRatePPT(Z, l, Δα, α_ion_au, ω0_au, Cnl, ip, occupancy,
+        msum, sum_integral, sum_tol, cycle_average)
+end
+
+function (ir::IonRatePPT)(E)
+    Ip_au = (ir.ionpot + ir.Δα/2 * E^2) / au_energy # Δα/2 * E^2 includes the Stark shift
+    ns = ir.Z/sqrt(2Ip_au)
+    ls = ns-1
+    Cnl2 = ismissing(ir.Cnl) ? 2^(2ns)/(ns*gamma(ns + ls + 1)*gamma(ns - ls)) : ir.Cnl^2
+
+    E0_au = (2*Ip_au)^(3/2)
+
+    E_au = abs(E)/au_Efield
+    γ = ir.ω0_au*sqrt(2Ip_au)/E_au
+    γ2 = γ*γ
+    β = 2γ/sqrt(1 + γ2)
+    α = 2*(asinh(γ) - γ/sqrt(1+γ2))
+    Up_au = E_au^2/(4*ir.ω0_au^2)
+    Uit_au = Ip_au + Up_au
+    v = Uit_au/ir.ω0_au
+    ret = 0
+    mrange = ir.msum ? (-ir.l:ir.l) : (0:0)
+    for m in mrange
+        mabs = abs(m)
+        flm = ((2ir.l + 1)*factorial(ir.l + mabs)
+            / (2^mabs*factorial(mabs)*factorial(ir.l - mabs)))
+        # Following 5 lines are [1] eq. 8 and lead to identical results:
+        # G = 3/(2γ)*((1 + 1/(2γ2))*asinh(γ) - sqrt(1 + γ2)/(2γ))
+        # Am = 4/(sqrt(3π)*factorial(mabs))*γ2/(1 + γ2)
+        # lret = sqrt(3/(2π))*Cnl2*flm*Ip_au
+        # lret *= (2*E0_au/(E_au*sqrt(1 + γ2))) ^ (2ns - mabs - 3/2)
+        # lret *= Am*exp(-2*E0_au*G/(3E_au))
+        # [2] eq. (A14)
+        lret = 4sqrt(2)/π*Cnl2
+        lret *= (2*E0_au/(E_au*sqrt(1 + γ2))) ^ (2ns - mabs - 3/2)
+        lret *= flm/factorial(mabs)
+        lret *= exp(-2v*(asinh(γ) - γ*sqrt(1+γ2)/(1+2γ2)))
+        lret *= Ip_au * γ2/(1+γ2)
+        # Remove cycle average factor, see eq. (2) of [1]
+        if !ir.cycle_average
+            lret *= sqrt(π*E0_au/(3E_au))
+        end
+        n0 = ceil(v)
+        if ir.sum_integral
+            s = sqrt(π)*factorial(mabs)*β^mabs/(2*(α+β)^(mabs+1))*sqrt(β/α)
+        else
+            s, _, _ = Maths.converge_series(0, n0=n0, rtol=ir.sum_tol, maxiter=Inf) do x, n
+                diff = n-v
+                x + exp(-α*diff)*φ(m, sqrt(β*diff))
+            end
+
+        end
+        lret *= s
+        ret += occ(ir.occupancy, m)*lret
+    end
+    if ir.α_ion_au ≠ 0
+        ret *= exp(-2*ir.α_ion_au*E_au)
+    end
+    return ret/au_time
+end
+
+occ(occupancy::Number, m) = occupancy
+occ(occupancy, m) = occupancy(m)
+
+"""
+    φ(m, x)
+
+Calculate the φ function for the PPT ionisation rate.
+
+Note that w_m(x) in [1] and φ_m(x) in [2] look slightly different but
+are in fact identical.
+"""
+function φ(m, x)
+    #= second half of [3], eq. 81
+        for m = 0, φ₀(x) is just the Dawson integral so we can get this directly.
+        for m ≠ 0, we calculate it using the hypergeometric function where possible.
+        for m ≠ 0 and large x, we need to do it brute force with BigFloats (slow)
+    =#
+    if m == 0
+        return dawson(x)
+    end
+
+    if x <= 26
+        mabs = abs(m)
+        return (exp(-x^2)
+            * sqrt(π)
+            * x^(2mabs+1)
+            * gamma(mabs+1)
+            * pFq((1/2,), (3/2 + mabs,), x^2)
+            / (2*gamma(3/2 + mabs)))
+    else
+        i, _ = hquadrature(0, x) do y
+            y = BigFloat(y)
+            x = BigFloat(x)
+            (x^2 - y^2)^(abs(m))*exp(y^2)
+        end
+        return Float64(exp(-x^2) * i)
+    end
+end
+
+function (ir::IonRatePPT)(out::AbstractArray, E::AbstractArray)
+    out .= ir.(E)
+end
+
+function ionrate_PPT(ionpot, λ0, Z, l, E; kwargs...)
+    return IonRatePPT(ionpot, λ0, Z, l; kwargs...).(E)
+end
+
+function ionrate_PPT(material::Symbol, λ0, E;
+                     stark_shift=true, dipole_corr=true, kwargs...)
+    _, l, Z = quantum_numbers(material)
+    Δα = stark_shift ? polarisability_difference(material) : 0
+    α_ion = dipole_corr ? polarisability(material, true) : 0
+    ip = ionisation_potential(material)
+    return ionrate_PPT(ip, λ0, Z, l, E; Δα, α_ion, kwargs...)
+end
+
+struct IonRatePPTAccel{ST} <: AbstractIonRate
+    spline::ST # spline interpolant
+    Emin::Float64 # minimum electric field strength
+    Emax::Float64 # maximum electric field strength
 end
 
 """
-    ionrate_fun!_PPTcached(material::Symbol, λ0; kwargs...)
-    ionrate_fun!_PPTcached(ionpot::Float64, λ0, Z, l; kwargs...)
+    IonRatePPTAccel(material::Symbol, λ0; kwargs...)
+    IonRatePPTAccel(ionpot::Float64, λ0, Z, l; kwargs...)
+    IonRatePPTAccel(E, rate)
 
 Create a cached (saved) interpolated PPT ionisation rate function. If a saved lookup table
 exists, load this rather than recalculate.
@@ -125,44 +340,63 @@ exists, load this rather than recalculate.
 # Keyword arguments
 - `N::Int`: Number of samples with which to create the `CSpline` interpolant.
 - `Emax::Number`: Maximum field strength to include in the interpolant.
+- `cache::Bool`: Whether to save the pre-calculated rate to a file
 - `cachedir::String`: Path to the directory where the cache should be stored and loaded from.
     Defaults to \$HOME/.luna/pptcache
 
-Other keyword arguments are passed on to [`ionrate_fun_PPT`](@ref)
+Other keyword arguments are passed on to [`IonRatePPT`](@ref)
 """
-function ionrate_fun!_PPTcached(material::Symbol, λ0;
-                                stark_shift=true, dipole_corr=true, kwargs...)
+function IonRatePPTAccel(E, rate)
+        # first remove points where the rate is zero within floating-point
+    # precision to avoid NaNs in the CSpline
+    idcs = rate .> 0
+    E = E[idcs]
+    rate = rate[idcs]
+    # Interpolating the log and re-exponentiating makes the spline more accurate
+    cspl = Maths.CSpline(E, log.(rate); bounds_error=true)
+    Emin = minimum(E)
+    Emax = maximum(E)
+    IonRatePPTAccel(cspl, Emin, Emax)
+end
+
+function IonRatePPTAccel(material::Symbol, λ0; stark_shift=true, dipole_corr=true, kwargs...)
     _, l, Z = quantum_numbers(material)
     Δα = stark_shift ? polarisability_difference(material) : 0
     α_ion = dipole_corr ? polarisability(material, true) : 0
     ip = ionisation_potential(material)
-    ionrate_fun!_PPTcached(ip, λ0, Z, l; Δα, α_ion, kwargs...)
+    IonRatePPTAccel(ip, λ0, Z, l; Δα, α_ion, kwargs...)
 end
 
-function ionrate_fun!_PPTcached(ionpot::Float64, λ0, Z, l;
-                                N=2^16, Emax=nothing,
-                                cachedir=joinpath(Utils.cachedir(), "pptcache"),
-                                stale_age=60*10,
-                                kwargs...)
+function IonRatePPTCached(args...; kwargs...)
+    IonRatePPTAccel(args...; cache=true, kwargs...)
+end
+
+function IonRatePPTAccel(ionpot::Float64, λ0, Z, l;
+    N=2^16, Emax=nothing, cache=true,
+    cachedir=joinpath(Utils.cachedir(), "pptcache"),
+    stale_age=60 * 10,
+    kwargs...)
     h = hash((ionpot, λ0, Z, l, N, Emax, collect(kwargs)))
-    fname = string(h, base=16)*".h5"
+    fname = string(h, base=16) * ".h5"
     fpath = joinpath(cachedir, fname)
-    lockpath = joinpath(cachedir, "pptlock")
-    isdir(cachedir) || mkpath(cachedir)
-    if isfile(fpath)
-        @info @sprintf("Found cached PPT rate for %.2f eV, %.1f nm", ionpot/electron, 1e9λ0)
-        rate = mkpidlock(lockpath; stale_age) do
-            loadPPTaccel(fpath)
+    if cache && isfile(fpath)
+        @info @sprintf("Found cached PPT rate for %.2f eV, %.1f nm", ionpot / electron, 1e9λ0)
+        E, rate = HDF5.h5open(fpath, "r") do file
+            (read(file["E"]), read(file["rate"]))
         end
-        return rate
     else
         E, rate = makePPTcache(ionpot::Float64, λ0, Z, l;
-                               N, Emax, kwargs...)
+            N, Emax, kwargs...)
+    end
+
+    if cache && ~isfile(fpath)
+        lockpath = joinpath(cachedir, "pptlock")
+        isdir(cachedir) || mkpath(cachedir)
         mkpidlock(lockpath; stale_age) do
             if ~isfile(fpath) # makePPTcache takes a while - has another process saved first?
                 @info @sprintf(
                     "Saving PPT rate for %.2f eV, %.1f nm in %s",
-                    ionpot/electron, 1e9λ0, fpath
+                    ionpot / electron, 1e9λ0, fpath
                 )
                 HDF5.h5open(fpath, "cw") do file
                     file["E"] = E
@@ -170,16 +404,26 @@ function ionrate_fun!_PPTcached(ionpot::Float64, λ0, Z, l;
                 end
             end
         end
-        return makePPTaccel(E, rate)
+    end
+
+    return IonRatePPTAccel(E, rate)
+end
+
+function (ir::IonRatePPTAccel)(E)
+    aE = abs(E)
+    if aE < ir.Emin
+        return 0.0
+    elseif aE > ir.Emax
+        error(
+            "Field strength $aE V/m exceeds maximum for PPT ionisation rate ($(ir.Emax) V/m)."
+            )
+    else
+        return exp(ir.spline(aE))
     end
 end
 
-function loadPPTaccel(fpath)
-    isfile(fpath) || error("PPT cache file $fpath not found!")
-    E, rate = HDF5.h5open(fpath, "r") do file
-        (read(file["E"]), read(file["rate"]))
-    end
-    makePPTaccel(E, rate)
+function (ir::IonRatePPTAccel)(out::AbstractArray, E::AbstractArray)
+    out .= ir.(E)
 end
 
 function makePPTcache(ionpot::Float64, λ0, Z, l;
@@ -231,7 +475,7 @@ Given an ionisation rate function `rate` and an electric field array `E` sampled
 spacing `δt`, calculate the ionisation fraction as a function of time on the same time axis.
 
 The function `rate` should have the signature `rate!(out, E)` and place its results into
-`out`, like the functions returned by e.g. `ionrate_fun!_ADK` or `ionrate_fun!_PPTcached`.
+`out`, like the functions returned by e.g. `IonRateADK` or `IonRatePPTCached`.
 """
 function ionfrac(rate, E, δt)
     frac = similar(E)
@@ -242,213 +486,6 @@ function ionfrac!(frac, rate, E, δt)
     rate(frac, E)
     Maths.cumtrapz!(frac, δt)
     @. frac = 1 - exp(-frac)
-end
-
-function makePPTaccel(E, rate)
-    # first remove points where the rate is zero within floating-point
-    # precision to avoid NaNs in the CSpline
-    idcs = rate .> 0
-    E = E[idcs]
-    rate = rate[idcs]
-    # Interpolating the log and re-exponentiating makes the spline more accurate
-    cspl = Maths.CSpline(E, log.(rate); bounds_error=true)
-    Emin = minimum(E)
-    Emax = maximum(E)
-    function ionrate!(out, E)
-        for ii in eachindex(out)
-            aE = abs(E[ii])
-            if aE < Emin
-                out[ii] = 0.0
-            elseif aE > Emax
-                error(
-                    "Field strength $aE V/m exceeds maximum for PPT ionisation rate ($Emax V/m)."
-                    )
-            else
-                out[ii] = exp(cspl(aE))
-            end
-        end
-    end
-end
-
-function ionrate_fun!_PPT(args...; kwargs...)
-    ir = ionrate_fun_PPT(args...; kwargs...)
-    function ionrate!(out, E)
-        out .= ir.(E)
-    end
-    return ionrate!
-end
-
-"""
-    ionrate_fun_PPT(ionpot::Float64, λ0, Z, l; kwargs...)
-
-Create closure to calculate PPT ionisation rate.
-
-# Keyword arguments
-- `sum_tol::Number`: Relative tolerance used to truncate the infinite sum. Defaults to 1e-6.
-- `cycle_average::Bool`: If `true`, calculate the cycle-averaged rate. Defaults to `false`.
-- `sum_integral::Bool`: whether to approximate the infinite sum in the PPT rate equation with
-    an integral (this neglects the multiphoton thresholds).
-- `Δα::Number`: polarisability difference between the ground state and the cation (in SI units)
-    to calculate the Stark shift of the ground-state energy levels. Defaults to 0.
-- `α_ion::Number`: polarisability of the cation (in SI units) to calculate the dipole correction
-    to the rate. Defaults to 0.
-- `msum::Bool`: for l ≠ 0, whether or not to sum over different m states. Defaults to `true`.
-- `Cnl::Real` : Pre-calculated `Cₙₗ` constant. If not given, defaults to the approximate expression from
-    the PPT papers.
-- `occupancy`: Occupancy of the state(s) from which ionisation is considered. Defaults to 2 for
-    a state with two electrons (spin up/down).
-
-# References
-[1] Ilkov, F. A., Decker, J. E. & Chin, S. L.
-Ionization of atoms in the tunnelling regime with experimental evidence
-using Hg atoms. Journal of Physics B: Atomic, Molecular and Optical
-Physics 25, 4005–4020 (1992)
-
-[2] Bergé, L., Skupin, S., Nuter, R., Kasparian, J. & Wolf, J.-P.
-Ultrashort filaments of light in weakly ionized, optically transparent
-media. Rep. Prog. Phys. 70, 1633–1713 (2007)
-(Appendix A)
-
-[3] A. Couairon and A. Mysyrowicz,
-"Femtosecond filamentation in transparent media,"
-Physics Reports 441(2–4), 47–189 (2007).
-
-"""
-function ionrate_fun_PPT(ionpot::Float64, λ0, Z, l;
-                         sum_tol=1e-6, cycle_average=false, sum_integral=false,
-                         Δα=0, α_ion=0, msum=true, Cnl=missing, occupancy=2)
-
-    if ismissing(Δα)
-        Δα = 0
-    end
-
-    if ismissing(α_ion)
-        α_ion = 0
-    end
-
-    α_ion_au = α_ion/au_polarisability
-
-    function ionrate(E)
-        Ip_au = (ionpot + Δα/2 * E^2) / au_energy # Δα/2 * E^2 includes the Stark shift
-        ns = Z/sqrt(2Ip_au)
-        ls = ns-1
-        Cnl2 = ismissing(Cnl) ? 2^(2ns)/(ns*gamma(ns + ls + 1)*gamma(ns - ls)) : Cnl^2
-
-        ω0 = 2π*c/λ0
-        ω0_au = au_time*ω0
-        E0_au = (2*Ip_au)^(3/2)
-
-        E_au = abs(E)/au_Efield
-        γ = ω0_au*sqrt(2Ip_au)/E_au
-        γ2 = γ*γ
-        β = 2γ/sqrt(1 + γ2)
-        α = 2*(asinh(γ) - γ/sqrt(1+γ2))
-        Up_au = E_au^2/(4*ω0_au^2)
-        Uit_au = Ip_au + Up_au
-        v = Uit_au/ω0_au
-        ret = 0
-        mrange = msum ? (-l:l) : (0:0)
-        for m in mrange
-            mabs = abs(m)
-            flm = ((2l + 1)*factorial(l + mabs)
-                / (2^mabs*factorial(mabs)*factorial(l - mabs)))
-            # Following 5 lines are [1] eq. 8 and lead to identical results:
-            # G = 3/(2γ)*((1 + 1/(2γ2))*asinh(γ) - sqrt(1 + γ2)/(2γ))
-            # Am = 4/(sqrt(3π)*factorial(mabs))*γ2/(1 + γ2)
-            # lret = sqrt(3/(2π))*Cnl2*flm*Ip_au
-            # lret *= (2*E0_au/(E_au*sqrt(1 + γ2))) ^ (2ns - mabs - 3/2)
-            # lret *= Am*exp(-2*E0_au*G/(3E_au))
-            # [2] eq. (A14)
-            lret = 4sqrt(2)/π*Cnl2
-            lret *= (2*E0_au/(E_au*sqrt(1 + γ2))) ^ (2ns - mabs - 3/2)
-            lret *= flm/factorial(mabs)
-            lret *= exp(-2v*(asinh(γ) - γ*sqrt(1+γ2)/(1+2γ2)))
-            lret *= Ip_au * γ2/(1+γ2)
-            # Remove cycle average factor, see eq. (2) of [1]
-            if !cycle_average
-                lret *= sqrt(π*E0_au/(3E_au))
-            end
-            n0 = ceil(v)
-            if sum_integral
-                s = sqrt(π)*factorial(mabs)*β^mabs/(2*(α+β)^(mabs+1))*sqrt(β/α)
-            else
-                s, _, _ = Maths.converge_series(0, n0=n0, rtol=sum_tol, maxiter=Inf) do x, n
-                    diff = n-v
-                    x + exp(-α*diff)*φ(m, sqrt(β*diff))
-                end
-
-            end
-            lret *= s
-            ret += occ(occupancy, m)*lret
-        end
-        if α_ion_au ≠ 0
-            ret *= exp(-2*α_ion_au*E_au)
-        end
-        return ret/au_time
-    end
-    return ionrate
-end
-
-occ(occupancy::Number, m) = occupancy
-occ(occupancy, m) = occupancy(m)
-
-"""
-    φ(m, x)
-
-Calculate the φ function for the PPT ionisation rate.
-
-Note that w_m(x) in [1] and φ_m(x) in [2] look slightly different but
-are in fact identical.
-"""
-function φ(m, x)
-    #= second half of [3], eq. 81
-        for m = 0, φ₀(x) is just the Dawson integral so we can get this directly.
-        for m ≠ 0, we calculate it using the hypergeometric function where possible.
-        for m ≠ 0 and large x, we need to do it brute force with BigFloats (slow)
-    =#
-    if m == 0
-        return dawson(x)
-    end
-
-    if x <= 26
-        mabs = abs(m)
-        return (exp(-x^2)
-            * sqrt(π)
-            * x^(2mabs+1)
-            * gamma(mabs+1)
-            * pFq((1/2,), (3/2 + mabs,), x^2)
-            / (2*gamma(3/2 + mabs)))
-    else
-        i, _ = hquadrature(0, x) do y
-            y = BigFloat(y)
-            x = BigFloat(x)
-            (x^2 - y^2)^(abs(m))*exp(y^2)
-        end
-        return Float64(exp(-x^2) * i)
-    end
-end
-
-
-function ionrate_fun_PPT(material::Symbol, λ0;
-                         stark_shift=true, dipole_corr=true, kwargs...)
-    _, l, Z = quantum_numbers(material)
-    Δα = stark_shift ? polarisability_difference(material) : 0
-    α_ion = dipole_corr ? polarisability(material, true) : 0
-    ip = ionisation_potential(material)
-    return ionrate_fun_PPT(ip, λ0, Z, l; Δα, α_ion, kwargs...)
-end
-
-function ionrate_PPT(ionpot, λ0, Z, l, E; kwargs...)
-    return ionrate_fun_PPT(ionpot, λ0, Z, l; kwargs...).(E)
-end
-
-function ionrate_PPT(material::Symbol, λ0, E;
-                     stark_shift=true, dipole_corr=true, kwargs...)
-    _, l, Z = quantum_numbers(material)
-    Δα = stark_shift ? polarisability_difference(material) : 0
-    α_ion = dipole_corr ? polarisability(material, true) : 0
-    ip = ionisation_potential(material)
-    return ionrate_PPT(ip, λ0, Z, l, E; Δα, α_ion, kwargs...)
 end
 
 end

--- a/src/Ionisation.jl
+++ b/src/Ionisation.jl
@@ -380,6 +380,7 @@ function IonRatePPTAccel(ionpot::Float64, λ0, Z, l;
     fname = string(h, base=16) * ".h5"
     fpath = joinpath(cachedir, fname)
     if cache && isfile(fpath)
+        lockpath = joinpath(cachedir, "pptlock")
         E, rate = mkpidlock(lockpath; stale_age) do
             @info @sprintf("Found cached PPT rate for %.2f eV, %.1f nm", ionpot / electron, 1e9λ0)
             HDF5.h5open(fpath, "r") do file

--- a/src/Ionisation.jl
+++ b/src/Ionisation.jl
@@ -226,7 +226,7 @@ function (ir::IonRatePPT)(E)
     Up_au = E_au^2/(4*ir.ω0_au^2)
     Uit_au = Ip_au + Up_au
     v = Uit_au/ir.ω0_au
-    ret = 0
+    ret = 0.0
     mrange = ir.msum ? (-ir.l:ir.l) : (0:0)
     for m in mrange
         mabs = abs(m)
@@ -347,7 +347,7 @@ exists, load this rather than recalculate.
 Other keyword arguments are passed on to [`IonRatePPT`](@ref)
 """
 function IonRatePPTAccel(E, rate)
-        # first remove points where the rate is zero within floating-point
+    # first remove points where the rate is zero within floating-point
     # precision to avoid NaNs in the CSpline
     idcs = rate .> 0
     E = E[idcs]
@@ -380,9 +380,11 @@ function IonRatePPTAccel(ionpot::Float64, λ0, Z, l;
     fname = string(h, base=16) * ".h5"
     fpath = joinpath(cachedir, fname)
     if cache && isfile(fpath)
-        @info @sprintf("Found cached PPT rate for %.2f eV, %.1f nm", ionpot / electron, 1e9λ0)
-        E, rate = HDF5.h5open(fpath, "r") do file
-            (read(file["E"]), read(file["rate"]))
+        E, rate = mkpidlock(lockpath; stale_age) do
+            @info @sprintf("Found cached PPT rate for %.2f eV, %.1f nm", ionpot / electron, 1e9λ0)
+            HDF5.h5open(fpath, "r") do file
+                (read(file["E"]), read(file["rate"]))
+            end
         end
     else
         E, rate = makePPTcache(ionpot::Float64, λ0, Z, l;

--- a/src/Luna.jl
+++ b/src/Luna.jl
@@ -36,7 +36,7 @@ end
 """
     set_fftw_threads(nthr)
 
-Set number of threads to be used by FFTW. If set to `0`, the number of threads used by 
+Set number of threads to be used by FFTW. If set to `0`, the number of threads used by
 FFTW is determined automatically (see [`Utils.FFTWthreads()`](@ref))
 """
 function set_fftw_threads(nthr=0)
@@ -284,7 +284,7 @@ function setup(grid::Grid.RealGrid, xygrid::Grid.FreeGrid,
     flush(stderr)
     Utils.loadFFTwisdom()
     x = xygrid.x
-    y = xygrid.y          
+    y = xygrid.y
     xr = Array{Float64}(undef, length(grid.t), length(y), length(x))
     FT = FFTW.plan_rfft(xr, (1, 2, 3), flags=settings["fftw_flag"])
     Eωk = zeros(ComplexF64, length(grid.ω), length(y), length(x))
@@ -307,7 +307,7 @@ function setup(grid::Grid.EnvGrid, xygrid::Grid.FreeGrid,
     flush(stderr)
     Utils.loadFFTwisdom()
     x = xygrid.x
-    y = xygrid.y          
+    y = xygrid.y
     xr = Array{ComplexF64}(undef, length(grid.t), length(y), length(x))
     FT = FFTW.plan_fft(xr, (1, 2, 3), flags=settings["fftw_flag"])
     Eωk = zeros(ComplexF64, length(grid.ω), length(y), length(x))
@@ -393,12 +393,14 @@ end
 # run some code for precompilation
 Logging.with_logger(Logging.NullLogger()) do
     prop_capillary(125e-6, 0.3, :He, 1.0; λ0=800e-9, energy=1e-9,
-                    τfwhm=10e-15, λlims=(150e-9, 4e-6), trange=1e-12, saveN=11)
+                    τfwhm=10e-15, λlims=(150e-9, 4e-6), trange=1e-12, saveN=11,
+                    PPT_options=Dict(:cache => false))
     prop_capillary(125e-6, 0.3, :He, (1.0, 0); λ0=800e-9, energy=1e-9,
-                    τfwhm=10e-15, λlims=(150e-9, 4e-6), trange=1e-12, saveN=11)
+                    τfwhm=10e-15, λlims=(150e-9, 4e-6), trange=1e-12, saveN=11,
+                    PPT_options=Dict(:cache => false))
     prop_capillary(125e-6, 0.3, :He, 1.0; λ0=800e-9, energy=1e-9,
                     τfwhm=10e-15, λlims=(150e-9, 4e-6), trange=1e-12, saveN=11,
-                    modes=4)
+                    modes=4, PPT_options=Dict(:cache => false))
     p = Tools.capillary_params(120e-6, 10e-15, 800e-9, 125e-6, :He, P=1.0)
 
     # gnlse_sol.jl example but with N=1 and 100th of the fibre length

--- a/src/SFA.jl
+++ b/src/SFA.jl
@@ -51,7 +51,7 @@ strong-field approximation (SFA).
 function sfa_dipole(t, Et::Vector{<:Real}, gas, λ0;
                     gate=true, nflat=1/2, nramp=1/4,
                     depletion=true,
-                    irf! = depletion ? Ionisation.ionrate_fun!_PPTcached(gas, λ0) : nothing,
+                    irf! = depletion ? Ionisation.IonRatePPTCached(gas, λ0) : nothing,
                     dipole=approx_dipole(gas))
     if gate
         return sfa_dipole_fast(t, Et, gas, λ0; nflat, nramp, depletion, irf!, dipole)
@@ -101,7 +101,7 @@ function sfa_dipole(t, Et::Vector{<:Real}, gas, λ0;
             t_b_idcs = t_b_idcs[crop]
             τ = τ[crop]
         end
-        
+
         intA_this = intA[tidx] .- intA[t_b_idcs] # definite integral between t_b and t_r
         intAsq_this = intAsq[tidx] .- intAsq[t_b_idcs] # definite integral between t_b and t_r
 
@@ -130,7 +130,7 @@ function sfa_dipole(t, Et::Vector{<:Real}, gas, λ0;
         if gate
             integrand .*= sine_squared_gate.(τ, ω0, nflat, nramp)
         end
-        
+
         D[tidx] = 1im*integrate(t_b, integrand, SimpsonEven())
     end
 
@@ -140,7 +140,7 @@ end
 function sfa_dipole_fast(t, Et::Vector{<:Real}, gas, λ0;
                          nflat=1/2, nramp=1/4,
                          depletion=true,
-                         irf! = depletion ? Ionisation.ionrate_fun!_PPTcached(gas, λ0) : nothing,
+                         irf! = depletion ? Ionisation.IonRatePPTCached(gas, λ0) : nothing,
                          dipole=approx_dipole(gas))
 
     if depletion

--- a/test/test_ionisation.jl
+++ b/test/test_ionisation.jl
@@ -33,7 +33,7 @@ idx2 = ifun.(E) # indices found with brute-force method
 @test all(idx1 .== idx2)
 @test all(spl1.(E) .== spl2.(E))
 
-ratefun = Ionisation.IonRatePPTAccel(:He, 800e-9)
+ratefun = Ionisation.IonRatePPTAccel(:He, 800e-9; cache=false)
 out = ratefun.(E)
 @test all(isapprox.(out, rate, rtol=1e-2))
 
@@ -100,7 +100,8 @@ Utils.clear_cache()
     Eω, grid, linop, transform, FT, output = with_logger(NullLogger()) do
         Interface.prop_capillary_args(100e-6, 1, gas, 1;
                                       λ0, τfwhm=10e-15, energy=1e-6,
-                                      λlims=(200e-9, 4e-6), trange=0.5e-12)
+                                      λlims=(200e-9, 4e-6), trange=0.5e-12,
+                                      PPT_options=Dict(:cache => false))
     end
 
     plasma = transform.resp[2]
@@ -113,6 +114,7 @@ Utils.clear_cache()
         :sum_integral => false,
         :msum => true,
         :occupancy => 2,
+        :cache => false
     )
     ir2 = Ionisation.IonRatePPTAccel(gas, λ0; PPT_options...)
 

--- a/test/test_ionisation.jl
+++ b/test/test_ionisation.jl
@@ -3,13 +3,44 @@ using Luna
 import NumericalIntegration: integrate, SimpsonEven
 import Logging: with_logger, NullLogger
 
+@test Ionisation.ionrate_ADK(:He, 1e10) ≈ 2*1.2416371415312408e-18
+@test Ionisation.ionrate_ADK(:He, 2e10) ≈ 2*1.0772390893742478
+@test Ionisation.ionrate_ADK(:HeB, 2e10) ≈ 2*1.0772390893742478
+@test Ionisation.ionrate_ADK(:Ar , 7e9) ≈ 2*2.4422306306649472e-08
+@test Ionisation.ionrate_ADK(:Ar , 8e9) ≈ 2*4.494711488416766e-05
+
 E = collect(range(1e9, 1e11; length=32))
 @test Ionisation.ionrate_ADK(:He, E) == Ionisation.ionrate_ADK(:He, -E)
 
 @test isapprox(Ionisation.ionrate_PPT(:He, 800e-9, 1e10; dipole_corr=false), 2*1.40432138471583e-5, rtol=1e-3)
 @test isapprox(Ionisation.ionrate_PPT(:He, 800e-9, 1.3e10; dipole_corr=false), 2*0.04517809797503506, rtol=1e-3)
 
+Emin = 1e9
+Emax = 1e11
+N = 2^9
+E = collect(range(Emin, Emax, N))
+rate = Ionisation.ionrate_PPT.(:He, 800e-9, E)
+ifun(E0) =  E0 <= Emin ? 2 :
+            E0 >= Emax ? N :
+            ceil(Int, (E0-Emin)/(Emax-Emin)*N) + 1
+ifun2(x0) = x0 <= E[1] ? 2 :
+                x0 >= E[end] ? length(E) :
+                findfirst(x -> x>x0, E)
+spl1 = Maths.CSpline(E, rate, ifun)
+spl2 = Maths.CSpline(E, rate, ifun2)
+idx1 = ifun2.(E) # calculated indices
+idx2 = ifun.(E) # indices found with brute-force method
+@test all(idx1 .== idx2)
+@test all(spl1.(E) .== spl2.(E))
 
+ratefun = Ionisation.IonRatePPTAccel(:He, 800e-9)
+out = ratefun.(E)
+@test all(isapprox.(out, rate, rtol=1e-2))
+
+outneg = ratefun.(-E)
+@test out == outneg
+
+##
 @testset "cycle-averaging $gas" for gas in (:He, :Ar, :Xe)
 
     bsi = Tools.field_to_intensity(
@@ -23,7 +54,7 @@ E = collect(range(1e9, 1e11; length=32))
     Et = sin.(t)
 
     adk_avg = zero(E0)
-    rf! = Ionisation.ionrate_fun!_ADK(gas)
+    rf! = Ionisation.IonRateADK(gas)
     out = zero(Et)
     for (idx, E0i) in enumerate(E0)
         rf!(out, E0i*Et)
@@ -34,18 +65,64 @@ E = collect(range(1e9, 1e11; length=32))
     @test all(isapprox.(adk_avg, adk_avg_kw; rtol=0.05))
 end
 
-gas = :He
+##
+# Check that PPT_options are indeed passed through properly
+@testset for gas in (:He, :Ne, :Ar, :Kr, :Xe)
+    # select all non-default options--each of these will make a difference to the interpolant
+    PPT_options = Dict{Symbol, Any}(
+        :stark_shift => false,
+        :dipole_corr => false,
+        :sum_tol => 1e-4,
+        :sum_integral => true,
+        :msum => false,
+        :occupancy => 4,
+    )
 
-λ0 = 800e-9
+    λ0 = 800e-9
+    Eω, grid, linop, transform, FT, output = with_logger(NullLogger()) do
+        Interface.prop_capillary_args(100e-6, 1, gas, 1;
+                                      λ0, τfwhm=10e-15, energy=1e-6,
+                                      λlims=(200e-9, 4e-6), trange=0.5e-12,
+                                      PPT_options)
+    end
 
-Eω, grid, linop, transform, FT, output = with_logger(NullLogger()) do
-    Interface.prop_capillary_args(100e-6, 1, gas, 1;
-    λ0, τfwhm=10e-15, energy=1e-6,
-    λlims=(200e-9, 4e-6), trange=0.5e-12)
+    plasma = transform.resp[2]
+    ir = plasma.ratefunc
+
+    ir2 = Ionisation.IonRatePPTAccel(gas, λ0; PPT_options...)
+
+    @test ir2.cspl.x == ir.cspl.x
+    @test ir2.cspl.y == ir.cspl.y
+
+    # now same again with default options
+    Eω, grid, linop, transform, FT, output = with_logger(NullLogger()) do
+        Interface.prop_capillary_args(100e-6, 1, gas, 1;
+                                      λ0, τfwhm=10e-15, energy=1e-6,
+                                      λlims=(200e-9, 4e-6), trange=0.5e-12)
+    end
+
+    plasma = transform.resp[2]
+    ir = plasma.ratefunc
+
+    PPT_options = Dict{Symbol, Any}(
+        :stark_shift => true,
+        :dipole_corr => true,
+        :sum_tol => 1e-6,
+        :sum_integral => false,
+        :msum => true,
+        :occupancy => 2,
+    )
+    ir2 = Ionisation.IonRatePPTAccel(gas, λ0; PPT_options...)
+
+    @test ir2.cspl.x == ir.cspl.x
+    @test ir2.cspl.y == ir.cspl.y
 end
 
-plasma = transform.resp[2]
-ir = plasma.ratefunc
-
-println("Here!")
-ir2 = Ionisation.ionrate_fun!_PPTaccel(gas, λ0)
+@testset "preionisation" begin
+    @test_throws DomainError prop_capillary(265e-6, 0.01, :He, 0.1;
+                                            λ0=800e-9, trange=70e-15, λlims=(100e-9,6e-6),
+                                            τfwhm=6e-15, energy=1.5e-3, preionfrac=1.01)
+    @test_throws DomainError prop_capillary(265e-6, 0.01, :He, 0.1;
+                                            λ0=800e-9, trange=70e-15, λlims=(100e-9,6e-6),
+                                            τfwhm=6e-15, energy=1.5e-3, preionfrac=-0.001)
+end

--- a/test/test_ionisation.jl
+++ b/test/test_ionisation.jl
@@ -66,6 +66,7 @@ outneg = ratefun.(-E)
 end
 
 ##
+Utils.clear_cache()
 # Check that PPT_options are indeed passed through properly
 @testset for gas in (:He, :Ne, :Ar, :Kr, :Xe)
     # select all non-default options--each of these will make a difference to the interpolant
@@ -76,6 +77,7 @@ end
         :sum_integral => true,
         :msum => false,
         :occupancy => 4,
+        :cache => false
     )
 
     λ0 = 800e-9
@@ -91,8 +93,8 @@ end
 
     ir2 = Ionisation.IonRatePPTAccel(gas, λ0; PPT_options...)
 
-    @test ir2.cspl.x == ir.cspl.x
-    @test ir2.cspl.y == ir.cspl.y
+    @test ir2.spline.x == ir.spline.x
+    @test ir2.spline.y == ir.spline.y
 
     # now same again with default options
     Eω, grid, linop, transform, FT, output = with_logger(NullLogger()) do
@@ -114,8 +116,8 @@ end
     )
     ir2 = Ionisation.IonRatePPTAccel(gas, λ0; PPT_options...)
 
-    @test ir2.cspl.x == ir.cspl.x
-    @test ir2.cspl.y == ir.cspl.y
+    @test ir2.spline.x == ir.spline.x
+    @test ir2.spline.y == ir.spline.y
 end
 
 @testset "preionisation" begin

--- a/test/test_ionisation.jl
+++ b/test/test_ionisation.jl
@@ -3,50 +3,13 @@ using Luna
 import NumericalIntegration: integrate, SimpsonEven
 import Logging: with_logger, NullLogger
 
-@test Ionisation.ionrate_ADK(:He, 1e10) ≈ 1.2416371415312408e-18
-@test Ionisation.ionrate_ADK(:He, 2e10) ≈ 1.0772390893742478
-@test Ionisation.ionrate_ADK(:HeB, 2e10) ≈ 1.0772390893742478
-@test Ionisation.ionrate_ADK(:Ar , 7e9) ≈ 2.4422306306649472e-08
-@test Ionisation.ionrate_ADK(:Ar , 8e9) ≈ 4.494711488416766e-05
-
 E = collect(range(1e9, 1e11; length=32))
 @test Ionisation.ionrate_ADK(:He, E) == Ionisation.ionrate_ADK(:He, -E)
 
 @test isapprox(Ionisation.ionrate_PPT(:He, 800e-9, 1e10; dipole_corr=false), 2*1.40432138471583e-5, rtol=1e-3)
 @test isapprox(Ionisation.ionrate_PPT(:He, 800e-9, 1.3e10; dipole_corr=false), 2*0.04517809797503506, rtol=1e-3)
 
-Emin = 1e9
-Emax = 1e11
-N = 2^9
-E = collect(range(Emin, Emax, N))
-rate = Ionisation.ionrate_PPT.(:He, 800e-9, E)
-ifun(E0) =  E0 <= Emin ? 2 :
-            E0 >= Emax ? N : 
-            ceil(Int, (E0-Emin)/(Emax-Emin)*N) + 1
-ifun2(x0) = x0 <= E[1] ? 2 :
-                x0 >= E[end] ? length(E) :
-                findfirst(x -> x>x0, E)
-spl1 = Maths.CSpline(E, rate, ifun)
-spl2 = Maths.CSpline(E, rate, ifun2)
-idx1 = ifun2.(E) # calculated indices
-idx2 = ifun.(E) # indices found with brute-force method
-@test all(idx1 .== idx2)
-@test all(spl1.(E) .== spl2.(E))
 
-ratefun! = Ionisation.ionrate_fun!_PPTaccel(:He, 800e-9)
-out = similar(E)
-ratefun!(out, E)
-@test all(isapprox.(out, rate, rtol=1e-2))
-
-outneg = similar(out)
-ratefun!(outneg, -E)
-@test out == outneg
-
-outneg = similar(out)
-ratefun!(outneg, -E)
-@test out == outneg
-
-##
 @testset "cycle-averaging $gas" for gas in (:He, :Ar, :Xe)
 
     bsi = Tools.field_to_intensity(
@@ -71,64 +34,18 @@ ratefun!(outneg, -E)
     @test all(isapprox.(adk_avg, adk_avg_kw; rtol=0.05))
 end
 
-##
-# Check that PPT_options are indeed passed through properly
-@testset for gas in (:He, :Ne, :Ar, :Kr, :Xe)
-    # select all non-default options--each of these will make a difference to the interpolant
-    PPT_options = Dict{Symbol, Any}(
-        :stark_shift => false,
-        :dipole_corr => false,
-        :sum_tol => 1e-4,
-        :sum_integral => true,
-        :msum => false,
-        :occupancy => 4,
-    )
+gas = :He
 
-    λ0 = 800e-9
-    Eω, grid, linop, transform, FT, output = with_logger(NullLogger()) do
-        Interface.prop_capillary_args(100e-6, 1, gas, 1;
-                                      λ0, τfwhm=10e-15, energy=1e-6,
-                                      λlims=(200e-9, 4e-6), trange=0.5e-12,
-                                      PPT_options)
-    end
+λ0 = 800e-9
 
-    plasma = transform.resp[2]
-    ir = plasma.ratefunc
-
-    ir2 = Ionisation.ionrate_fun!_PPTaccel(gas, λ0; PPT_options...)
-
-    @test ir2.cspl.x == ir.cspl.x
-    @test ir2.cspl.y == ir.cspl.y
-
-    # now same again with default options
-    Eω, grid, linop, transform, FT, output = with_logger(NullLogger()) do
-        Interface.prop_capillary_args(100e-6, 1, gas, 1;
-                                      λ0, τfwhm=10e-15, energy=1e-6,
-                                      λlims=(200e-9, 4e-6), trange=0.5e-12)
-    end
-
-    plasma = transform.resp[2]
-    ir = plasma.ratefunc
-
-    PPT_options = Dict{Symbol, Any}(
-        :stark_shift => true,
-        :dipole_corr => true,
-        :sum_tol => 1e-6,
-        :sum_integral => false,
-        :msum => true,
-        :occupancy => 2,
-    )
-    ir2 = Ionisation.ionrate_fun!_PPTaccel(gas, λ0; PPT_options...)
-
-    @test ir2.cspl.x == ir.cspl.x
-    @test ir2.cspl.y == ir.cspl.y
+Eω, grid, linop, transform, FT, output = with_logger(NullLogger()) do
+    Interface.prop_capillary_args(100e-6, 1, gas, 1;
+    λ0, τfwhm=10e-15, energy=1e-6,
+    λlims=(200e-9, 4e-6), trange=0.5e-12)
 end
 
-@testset "preionisation" begin
-    @test_throws DomainError prop_capillary(265e-6, 0.01, :He, 0.1;
-                                            λ0=800e-9, trange=70e-15, λlims=(100e-9,6e-6),
-                                            τfwhm=6e-15, energy=1.5e-3, preionfrac=1.01)
-    @test_throws DomainError prop_capillary(265e-6, 0.01, :He, 0.1;
-                                            λ0=800e-9, trange=70e-15, λlims=(100e-9,6e-6),
-                                            τfwhm=6e-15, energy=1.5e-3, preionfrac=-0.001)
-end
+plasma = transform.resp[2]
+ir = plasma.ratefunc
+
+println("Here!")
+ir2 = Ionisation.ionrate_fun!_PPTaccel(gas, λ0)

--- a/test/test_ionisation.jl
+++ b/test/test_ionisation.jl
@@ -81,7 +81,7 @@ end
     )
 
     λ0 = 800e-9
-    Eω, grid, linop, transform, FT, output = begin
+    Eω, grid, linop, transform, FT, output = with_logger(NullLogger()) do
         Interface.prop_capillary_args(100e-6, 1, gas, 1;
                                       λ0, τfwhm=10e-15, energy=1e-6,
                                       λlims=(200e-9, 4e-6), trange=0.5e-12,
@@ -97,7 +97,7 @@ end
     @test ir2.spline.y == ir.spline.y
 
     # now same again with mostly default options (just fewer points, for speed)
-    Eω, grid, linop, transform, FT, output = begin
+    Eω, grid, linop, transform, FT, output = with_logger(NullLogger()) do
         Interface.prop_capillary_args(100e-6, 1, gas, 1;
                                       λ0, τfwhm=10e-15, energy=1e-6,
                                       λlims=(200e-9, 4e-6), trange=0.5e-12,

--- a/test/test_radial.jl
+++ b/test/test_radial.jl
@@ -38,7 +38,7 @@ end
 dens0 = PhysData.density(gas, pres)
 densityfun(z) = dens0
 ionpot = PhysData.ionisation_potential(gas)
-ionrate = Ionisation.ionrate_fun!_PPTcached(gas, λ0)
+ionrate = Ionisation.IonRatePPTCached(gas, λ0)
 responses = (Nonlinear.Kerr_field(PhysData.γ3_gas(gas)),
              Nonlinear.PlasmaCumtrapz(grid.to, grid.to, ionrate, ionpot))
 linop = LinearOps.make_const_linop(grid, q, PhysData.ref_index_fun(gas, pres))

--- a/test/test_vectorplasma.jl
+++ b/test/test_vectorplasma.jl
@@ -16,14 +16,14 @@ import Test: @test, @testset, @test_throws
     dens0 = PhysData.density(gas, pres)
     densityfun(z) = dens0
     ionpot = PhysData.ionisation_potential(gas)
-    ionrate = Ionisation.ionrate_fun!_ADK(ionpot)
+    ionrate = Ionisation.IonRateADK(ionpot)
     # scalar modal
     modes = (
         Capillary.MarcatiliMode(a, gas, pres, n=1, m=1, kind=:HE, ϕ=0.0, loss=false),
     )
     nmodes = length(modes)
     plasma = Nonlinear.PlasmaCumtrapz(grid.to, grid.to,
-                                    ionrate, ionpot)              
+                                    ionrate, ionpot)
     responses = (Nonlinear.Kerr_field(PhysData.γ3_gas(gas)),
                 plasma)
     inputs = Fields.GaussField(λ0=λ0, τfwhm=τfwhm, energy=energy)
@@ -35,7 +35,7 @@ import Test: @test, @testset, @test_throws
     Luna.run(Eω, grid, linop, transform, FT, outscalar)
     # vector linear 0 degrees
     plasma = Nonlinear.PlasmaCumtrapz(grid.to, Array{Float64}(undef, length(grid.to), 2),
-                                      ionrate, ionpot)                  
+                                      ionrate, ionpot)
     responses = (Nonlinear.Kerr_field(PhysData.γ3_gas(gas)),
              plasma)
     Eω, transform, FT = Luna.setup(grid, densityfun, responses, inputs, modes,


### PR DESCRIPTION
~for now this PR is just to trigger CI runs. this MWE of the ionisation test crashes on my MacBook~

Since the GC corruption is due to a Julia bug (https://github.com/JuliaLang/julia/issues/60985), this doesn't fix the problem. However, the refactor of the Ionisation module still makes sense IMO. Ionisation rates are now functors rather than closures. Instead of
```julia
ionrate = Ionisation.ionrate_fun!_PPTcached(gas, λ0)
```
it's now
```julia
ionrate = Ionisation.IonRatePPTCached(gas, λ0)
```
A simple find & replace should fix this in any scripts using the low-level interface directly.

And similarly for other rates. The simple functions `ionrate_PPT` and `ionrate_ADK` still exist, but internally create the functors.