### PR TITLE
enable orthogonal polarisation for HEnm with n != 1

### DIFF
--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -373,13 +373,23 @@ function prop_capillary_args(radius, flength, gas, pressure;
                         saveN=201, filepath=nothing,
                         scan=nothing, scanidx=nothing, filename=nothing)
 
-    pol = needpol(polarisation, pulses) || needpol_modes(modes)
-    @info "X+Y polarisation "* (pol ? "required." : "not required.")
+    # do we have energy in the orthogonal polarisation states, or just the fundamental?
+    # if so, we need to treat double the number of modes
+    both_modes = needpol(polarisation, pulses)
+    @info "Orthogonal polarisation modes are "* (both_modes ? "required." : "not required.")
+    #= need to treat vector fields if:
+        a) we have both polarisation states in the field AND/OR
+        b) the modes themselves contain x and y polarisation components
+    =#
+    pol = both_modes || needpol_modes(modes)
+    @info "Vector fields are "* (pol ? "required." : "not required.")
+
     plasma = isnothing(plasma) ? !envelope : plasma
     thg = isnothing(thg) ? !envelope : thg
 
     grid = makegrid(flength, λ0, λlims, trange, envelope, thg, δt)
-    mode_s = makemode_s(modes, flength, radius, gas, pressure, temperature, model, loss, pol)
+    mode_s = makemode_s(
+        modes, flength, radius, gas, pressure, temperature, model, loss, both_modes)
     check_orth(mode_s)
     density = makedensity(flength, gas, pressure, temperature)
     resp = makeresponse(grid, gas, raman, kerr, plasma, thg, pol, rotation, vibration,
@@ -475,12 +485,12 @@ end
 
 parse_mode(mode::Dict) = mode
 
-function makemodes_pol(pol, args...; kwargs...)
-    if pol
+function makemodes_pol(both, args...; kwargs...)
+    if both
         if kwargs[:kind] == :HE
             return [Capillary.MarcatiliMode(args...; ϕ=0.0, kwargs...),
                     Capillary.MarcatiliMode(args...; ϕ=π/(2*kwargs[:n]), kwargs...)]
-        else
+        else # TE/TM: there is only one mode
             return [Capillary.MarcatiliMode(args...; ϕ=0.0, kwargs...)]
         end
     else
@@ -488,20 +498,20 @@ function makemodes_pol(pol, args...; kwargs...)
     end
 end
 
-function makemode_s(mode::Union{Symbol, Dict}, flength, radius, gas, pressure::Number, temperature, model, loss, pol)
-    makemodes_pol(pol, radius, gas, pressure; T=temperature, model, loss, parse_mode(mode)...)
+function makemode_s(mode::Union{Symbol, Dict}, flength, radius, gas, pressure::Number, temperature, model, loss, both)
+    makemodes_pol(both, radius, gas, pressure; T=temperature, model, loss, parse_mode(mode)...)
 end
 
 function makemode_s(mode::Union{Symbol, Dict}, flength, radius, gas, pressure::Tuple{<:Number, <:Number},
-                    temperature, model, loss, pol)
+                    temperature, model, loss, both)
     coren, _ = Capillary.gradient(gas, flength, pressure..., T=temperature)
-    makemodes_pol(pol, radius, coren; model, loss, parse_mode(mode)...)
+    makemodes_pol(both, radius, coren; model, loss, parse_mode(mode)...)
 end
 
-function makemode_s(mode::Union{Symbol, Dict}, flength, radius, gas, pressure, temperature, model, loss, pol)
+function makemode_s(mode::Union{Symbol, Dict}, flength, radius, gas, pressure, temperature, model, loss, both)
     Z, P = pressure
     coren, _ = Capillary.gradient(gas, Z, P, T=temperature)
-    makemodes_pol(pol, radius, coren; model, loss, parse_mode(mode)...)
+    makemodes_pol(both, radius, coren; model, loss, parse_mode(mode)...)
 end
 
 function makemode_s(modes::Int, args...)

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -770,14 +770,24 @@ function ellfields(pulse::Union{Pulses.CustomPulse, Pulses.GaussPulse, Pulses.Se
     f1, f2
 end
 
-function ellfields(pulse::Pulses.DataPulse)
-    f = pulse.field.field
-    pf = pulse.field
+ellfields(pulse::Pulse.DataPulse) = ellfields(pulse, pulse.field)
+
+function ellfields(pulse::Pulses.DataPulse, pf::Fields.PropagatedField)
+    f = pf.field
     py, px = ellfac(pulse.polarisation)
     f1 = Fields.DataField(f.ω, f.Iω, f.ϕω, nmult(f.energy, py), f.ϕ, f.λ0)
     f2 = Fields.DataField(f.ω, f.Iω, f.ϕω, nmult(f.energy, px),
                           ellphase(f.ϕ, pulse.polarisation), f.λ0)
     Fields.PropagatedField(pf.propagator!, f1), Fields.PropagatedField(pf.propagator!, f2)
+end
+
+function ellfields(pulse::Pulses.DataPulse, pf)
+    f = pf.field
+    py, px = ellfac(pulse.polarisation)
+    f1 = Fields.DataField(f.ω, f.Iω, f.ϕω, nmult(f.energy, py), f.ϕ, f.λ0)
+    f2 = Fields.DataField(f.ω, f.Iω, f.ϕω, nmult(f.energy, px),
+                          ellphase(f.ϕ, pulse.polarisation), f.λ0)
+    f1, f2
 end
 
 function shotnoise_maybe(inputs, mode::Modes.AbstractMode, shotnoise::Bool)

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -770,7 +770,7 @@ function ellfields(pulse::Union{Pulses.CustomPulse, Pulses.GaussPulse, Pulses.Se
     f1, f2
 end
 
-ellfields(pulse::Pulse.DataPulse) = ellfields(pulse, pulse.field)
+ellfields(pulse::Pulses.DataPulse) = ellfields(pulse, pulse.field)
 
 function ellfields(pulse::Pulses.DataPulse, pf::Fields.PropagatedField)
     f = pf.field

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -477,9 +477,9 @@ parse_mode(mode::Dict) = mode
 
 function makemodes_pol(pol, args...; kwargs...)
     if pol
-        if kwargs[:kind] == :HE && kwargs[:n] == 1
+        if kwargs[:kind] == :HE
             return [Capillary.MarcatiliMode(args...; ϕ=0.0, kwargs...),
-                    Capillary.MarcatiliMode(args...; ϕ=π/2, kwargs...)]
+                    Capillary.MarcatiliMode(args...; ϕ=π/(2*kwargs[:n]), kwargs...)]
         else
             return [Capillary.MarcatiliMode(args...; ϕ=0.0, kwargs...)]
         end

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -782,7 +782,7 @@ function ellfields(pulse::Pulses.DataPulse, pf::Fields.PropagatedField)
 end
 
 function ellfields(pulse::Pulses.DataPulse, pf)
-    f = pf.field
+    f = pf
     py, px = ellfac(pulse.polarisation)
     f1 = Fields.DataField(f.ω, f.Iω, f.ϕω, nmult(f.energy, py), f.ϕ, f.λ0)
     f2 = Fields.DataField(f.ω, f.Iω, f.ϕω, nmult(f.energy, px),

--- a/test/test_interface.jl
+++ b/test/test_interface.jl
@@ -81,44 +81,47 @@ end
 end
 
 ##
+prop!(Eω, grid) = nothing # do-nothing propagator
 @testset "Input into higher-order modes" begin
-    args = (100e-6, 0.1, :He, 1)
-    kwargs = (λ0=800e-9, shotnoise=false, trange=250e-15, λlims=(200e-9, 4e-6),
-               saveN=51, plasma=false)
-    pkwargs = (τfwhm=10e-15, energy=1e-12, λ0=800e-9)
-    @testset "input into $m, mode average" for m in (:HE11, :HE12, :TE01, :TE02, :TM01)
-        ip = Pulses.GaussPulse(;mode=m, pkwargs...)
-        o = prop_capillary(args...; pulses=ip, modes=m, kwargs...)
-        @test Processing.energy(o)[1] ≈ pkwargs.energy
-    end
-    @testset "input into $m, modal" for (midx, m) in enumerate((:HE11, :HE12, :HE13, :HE14))
-        ip = Pulses.GaussPulse(;mode=m, pkwargs...)
-        o = prop_capillary(args...; pulses=ip, modes=4, kwargs...)
-        @test Processing.energy(o)[midx, 1] ≈ pkwargs.energy
-    end
-    @testset "input into $m, modal circular" for (midx, m) in enumerate((:HE11, :HE12, :HE13, :HE14))
-        ip = Pulses.GaussPulse(;mode=m, polarisation=:circular, pkwargs...)
-        o = prop_capillary(args...; pulses=ip, modes=4, kwargs...)
-        @test Processing.energy(o)[2midx-1, 1] ≈ pkwargs.energy/2
-        @test Processing.energy(o)[2midx, 1] ≈ pkwargs.energy/2
-    end
-    modes = (:HE21, :HE22, :HE23, :HE24)
-    @testset "input into $m, modal" for (midx, m) in enumerate(modes)
-        ip = Pulses.GaussPulse(;mode=m, pkwargs...)
-        o = prop_capillary(args...; pulses=ip, modes, kwargs...)
-        @test Processing.energy(o)[midx, 1] ≈ pkwargs.energy
-    end
-    @testset "input into $m, modal circular" for (midx, m) in enumerate(modes)
-        ip = Pulses.GaussPulse(;mode=m, polarisation=:circular, pkwargs...)
-        o = prop_capillary(args...; pulses=ip, modes, kwargs...)
-        @test Processing.energy(o)[2midx-1, 1] ≈ pkwargs.energy/2
-        @test Processing.energy(o)[2midx, 1] ≈ pkwargs.energy/2
-    end
-    modes = (:TE01, :TE02, :TE03, :TE04, :TM01, :TM02, :TM03, :TM04)
-    @testset "input into $m, modal" for (midx, m) in enumerate((modes))
-        ip = Pulses.GaussPulse(;mode=m, pkwargs...)
-        o = prop_capillary(args...; pulses=ip, modes=modes, kwargs...)
-        @test Processing.energy(o)[midx, 1] ≈ pkwargs.energy
+    @testset "propagator $prop" for prop in (nothing, prop!)
+        args = (100e-6, 0.1, :He, 1)
+        kwargs = (λ0=800e-9, shotnoise=false, trange=250e-15, λlims=(200e-9, 4e-6),
+                saveN=51, plasma=false, propagator=prop)
+        pkwargs = (τfwhm=10e-15, energy=1e-12, λ0=800e-9)
+        @testset "input into $m, mode average" for m in (:HE11, :HE12, :TE01, :TE02, :TM01)
+            ip = Pulses.GaussPulse(;mode=m, pkwargs...)
+            o = prop_capillary(args...; pulses=ip, modes=m, kwargs...)
+            @test Processing.energy(o)[1] ≈ pkwargs.energy
+        end
+        @testset "input into $m, modal" for (midx, m) in enumerate((:HE11, :HE12, :HE13, :HE14))
+            ip = Pulses.GaussPulse(;mode=m, pkwargs...)
+            o = prop_capillary(args...; pulses=ip, modes=4, kwargs...)
+            @test Processing.energy(o)[midx, 1] ≈ pkwargs.energy
+        end
+        @testset "input into $m, modal circular" for (midx, m) in enumerate((:HE11, :HE12, :HE13, :HE14))
+            ip = Pulses.GaussPulse(;mode=m, polarisation=:circular, pkwargs...)
+            o = prop_capillary(args...; pulses=ip, modes=4, kwargs...)
+            @test Processing.energy(o)[2midx-1, 1] ≈ pkwargs.energy/2
+            @test Processing.energy(o)[2midx, 1] ≈ pkwargs.energy/2
+        end
+        modes = (:HE21, :HE22, :HE23, :HE24)
+        @testset "input into $m, modal" for (midx, m) in enumerate(modes)
+            ip = Pulses.GaussPulse(;mode=m, pkwargs...)
+            o = prop_capillary(args...; pulses=ip, modes, kwargs...)
+            @test Processing.energy(o)[midx, 1] ≈ pkwargs.energy
+        end
+        @testset "input into $m, modal circular" for (midx, m) in enumerate(modes)
+            ip = Pulses.GaussPulse(;mode=m, polarisation=:circular, pkwargs...)
+            o = prop_capillary(args...; pulses=ip, modes, kwargs...)
+            @test Processing.energy(o)[2midx-1, 1] ≈ pkwargs.energy/2
+            @test Processing.energy(o)[2midx, 1] ≈ pkwargs.energy/2
+        end
+        modes = (:TE01, :TE02, :TE03, :TE04, :TM01, :TM02, :TM03, :TM04)
+        @testset "input into $m, modal" for (midx, m) in enumerate((modes))
+            ip = Pulses.GaussPulse(;mode=m, pkwargs...)
+            o = prop_capillary(args...; pulses=ip, modes=modes, kwargs...)
+            @test Processing.energy(o)[midx, 1] ≈ pkwargs.energy
+        end
     end
 end
 

--- a/test/test_interface.jl
+++ b/test/test_interface.jl
@@ -102,6 +102,18 @@ end
         @test Processing.energy(o)[2midx-1, 1] ≈ pkwargs.energy/2
         @test Processing.energy(o)[2midx, 1] ≈ pkwargs.energy/2
     end
+    modes = (:HE21, :HE22, :HE23, :HE24)
+    @testset "input into $m, modal" for (midx, m) in enumerate(modes)
+        ip = Pulses.GaussPulse(;mode=m, pkwargs...)
+        o = prop_capillary(args...; pulses=ip, modes, kwargs...)
+        @test Processing.energy(o)[midx, 1] ≈ pkwargs.energy
+    end
+    @testset "input into $m, modal circular" for (midx, m) in enumerate(modes)
+        ip = Pulses.GaussPulse(;mode=m, polarisation=:circular, pkwargs...)
+        o = prop_capillary(args...; pulses=ip, modes, kwargs...)
+        @test Processing.energy(o)[2midx-1, 1] ≈ pkwargs.energy/2
+        @test Processing.energy(o)[2midx, 1] ≈ pkwargs.energy/2
+    end
     modes = (:TE01, :TE02, :TE03, :TE04, :TM01, :TM02, :TM03, :TM04)
     @testset "input into $m, modal" for (midx, m) in enumerate((modes))
         ip = Pulses.GaussPulse(;mode=m, pkwargs...)


### PR DESCRIPTION
This removes an unnecessary restriction in the interface code, where the modes orthogonal polarisation are only created for HE1m but not for higher orders. This means that one can now use this to run e.g. a simulation in HE21 with circular polarisation. 

New test to make sure this works.