### PR TITLE
BSI ionisation correction for strong fields

### DIFF
--- a/examples/low_level_interface/PPT_ionisation_rate/PPT_ionisation_rate.jl
+++ b/examples/low_level_interface/PPT_ionisation_rate/PPT_ionisation_rate.jl
@@ -10,10 +10,11 @@ this_folder = dirname(@__FILE__)
 ## Ilkov et al
 k = collect(range(10, stop=12, length=50))
 E = 10 .^ k
-# ppt = Ionisation.ionrate_PPT(:He, 10.6e-6, E)
-ppt_cycavg = Ionisation.ionrate_PPT(:He, 10.6e-6, E, cycle_average=true, sum_tol=1e-6, stark_shift=false)
-ppt_cycavg_rough = Ionisation.ionrate_PPT(:He, 10.6e-6, E, cycle_average=true, sum_tol=1e-4, stark_shift=false)
-ppt_cycavg_intg = Ionisation.ionrate_PPT(:He, 10.6e-6, E, cycle_average=true, sum_integral=true, stark_shift=false)
+# bsi=:none keeps these the bare PPT rate, for comparison with the (bare-PPT) literature data
+# ppt = Ionisation.ionrate_PPT(:He, 10.6e-6, E; bsi=:none)
+ppt_cycavg = Ionisation.ionrate_PPT(:He, 10.6e-6, E, cycle_average=true, sum_tol=1e-6, stark_shift=false, bsi=:none)
+ppt_cycavg_rough = Ionisation.ionrate_PPT(:He, 10.6e-6, E, cycle_average=true, sum_tol=1e-4, stark_shift=false, bsi=:none)
+ppt_cycavg_intg = Ionisation.ionrate_PPT(:He, 10.6e-6, E, cycle_average=true, sum_integral=true, stark_shift=false, bsi=:none)
 adk = Ionisation.ionrate_ADK(:He, E)
 
 dat = readdlm(joinpath(this_folder, "Ilkov_PPT_He.csv"), ',') # ionrate [1/s] vs field [V/cm]
@@ -37,8 +38,8 @@ plt.title("He ionisation at 10.6 μm (Stark shift off, divided by 2)")
 dat = readdlm(joinpath(this_folder, "Chang_PPT.csv"), ',') # ionrate [1/fs] vs intensity [1e14 W/cm^2]
 intensity = range(0.1, 25; length=100) * 1e18 # W/m^2
 E = Tools.intensity_to_field.(intensity)
-ppt = Ionisation.ionrate_PPT(:He, 390e-9, E)
-ppt_cycavg = Ionisation.ionrate_PPT(:He, 390e-9, E, cycle_average=true)
+ppt = Ionisation.ionrate_PPT(:He, 390e-9, E; bsi=:none)
+ppt_cycavg = Ionisation.ionrate_PPT(:He, 390e-9, E, cycle_average=true, bsi=:none)
 adk = Ionisation.ionrate_ADK(:He, E)
 
 s = sortperm(dat[:, 1])
@@ -86,11 +87,11 @@ intensity = 10 .^ k .* 1e4 # W/m^2
 E = Tools.intensity_to_field.(intensity)
 λ0 = 800e-9
 gas = :Ar
-# ppt = Ionisation.ionrate_PPT(gas, λ0, E)
+# ppt = Ionisation.ionrate_PPT(gas, λ0, E; bsi=:none)
 sum_tol = 1e-5
-ppt_cycavg = Ionisation.ionrate_PPT(gas, λ0, E; cycle_average=true, sum_tol)
-ppt_cycavg_m0 = Ionisation.ionrate_PPT(gas, λ0, E; cycle_average=true, sum_tol, msum=false)
-ppt_cycavg_msum_nostark = Ionisation.ionrate_PPT(gas, λ0, E; cycle_average=true, stark_shift=false)
+ppt_cycavg = Ionisation.ionrate_PPT(gas, λ0, E; cycle_average=true, sum_tol, bsi=:none)
+ppt_cycavg_m0 = Ionisation.ionrate_PPT(gas, λ0, E; cycle_average=true, sum_tol, msum=false, bsi=:none)
+ppt_cycavg_msum_nostark = Ionisation.ionrate_PPT(gas, λ0, E; cycle_average=true, stark_shift=false, bsi=:none)
 
 s = sortperm(dat[:, 1])
 
@@ -117,7 +118,7 @@ ppt = zeros((length(E), length(sum_tol)))
 gas = :He
 λ0 = 1800e-9
 for (idx, sti) in enumerate(sum_tol)
-    ppt[:, idx] .= Ionisation.ionrate_PPT(gas, λ0, E; sum_tol=sti)
+    ppt[:, idx] .= Ionisation.ionrate_PPT(gas, λ0, E; sum_tol=sti, bsi=:none)
 end
 ##
 cols = plt.get_cmap().(collect(range(0, 0.8, length(sum_tol))))

--- a/examples/low_level_interface/PPT_ionisation_rate/bsi_correction.jl
+++ b/examples/low_level_interface/PPT_ionisation_rate/bsi_correction.jl
@@ -1,0 +1,56 @@
+# Barrier-suppression (over-the-barrier) corrections to the PPT ionisation rate.
+#
+# Two-panel comparison for He @ 800 nm:
+#   (a) the multiplicative correction factor W_corr / W_PPT vs E / E_b
+#   (b) the resulting rate vs field for bare PPT, PPT × Tong–Lin and PPT × Zhang.
+#
+# Tong & Lin, J. Phys. B 38, 2593 (2005); Zhang, Lan & Lu, Phys. Rev. A 90, 043410 (2014).
+# See the CORRECTNESS NOTE in src/Ionisation.jl on the sign typo in Zhang eq. (8): if the
+# Zhang factor in panel (a) ever rises above 1, that typo has been reintroduced.
+
+import Luna: Ionisation, PhysData
+import Luna.PhysData: au_Efield, c, ε_0
+import PyPlot: plt, pygui
+
+pygui(true)
+
+λ0 = 800e-9
+gas = :He
+Ip_au = PhysData.ionisation_potential(gas) / PhysData.au_energy
+Z = 1.0
+Eb_au = Ip_au^2 / (4Z)
+Eb = Eb_au * au_Efield                      # V/m
+
+none = Ionisation.IonRatePPT(gas, λ0; bsi=:none)
+tl   = Ionisation.IonRatePPT(gas, λ0; bsi=:tonglin)
+zh   = Ionisation.IonRatePPT(gas, λ0; bsi=:zhang)
+
+x  = range(0.3, 4.7; length=400)            # E / E_b
+E  = collect(x) .* Eb
+Wn = none.(E); Wt = tl.(E); Wz = zh.(E)
+intensity(Ef) = 0.5c*ε_0*Ef^2 / 1e4         # W/cm^2
+
+fig, (axL, axR) = plt.subplots(1, 2; figsize=(13, 5))
+
+# (a) correction factor
+axL.axvspan(0.5, 1.3; color="#ffe08a", alpha=0.55)        # operating range
+axL.plot(x, Wt ./ Wn; lw=2.5, color="#c0392b", label="Tong–Lin (2005), α=7")
+axL.plot(x, Wz ./ Wn; lw=2.5, color="#1f5fa6", label="Zhang et al. (2014)")
+axL.axvline(2.0; ls=":", color="#c0392b"); axL.axvline(4.5; ls=":", color="#1f5fa6")
+axL.set_xlabel("E / E_b"); axL.set_ylabel("W_corr / W_PPT")
+axL.set_ylim(0, 1.02); axL.legend(frameon=false); axL.grid(alpha=0.25)
+axL.set_title("(a) correction factor")
+
+# (b) resulting rate
+axR.semilogy(x, Wn; ls="--", color="0.55", lw=2, label="bare PPT (overestimates)")
+axR.semilogy(x, Wt; color="#c0392b", lw=2.5, label="PPT × Tong–Lin")
+axR.semilogy(x, Wz; color="#1f5fa6", lw=2.5, label="PPT × Zhang")
+axR.axvspan(0.5, 1.3; color="#ffe08a", alpha=0.55)
+axR.set_xlabel("E / E_b"); axR.set_ylabel("rate (1/s)")
+axR.legend(frameon=false); axR.grid(alpha=0.25, which="both")
+axR.set_title("(b) resulting He rate")
+
+fig.suptitle("He barrier-suppression corrections  (E_b = $(round(Eb_au; digits=3)) a.u. " *
+             "= $(round(Eb/1e11; digits=2))×10¹¹ V/m)")
+fig.tight_layout()
+#fig.savefig(joinpath(dirname(@__FILE__), "bsi_correction_He.png"); dpi=150)

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -330,7 +330,10 @@ In this case, all keyword arguments except for `λ0` are ignored.
 - `PPT_options::Dict{Symbol, Any}`: when using the PPT ionisation rate for the
     plasma nonlinearity, this allows for fine-tuning of the options in calculating
     the ionisation. See [`IonRatePPTAccel`](@ref Ionisation.IonRatePPTAccel) for possible
-    keyword arguments.
+    keyword arguments. By default the barrier-suppression correction `bsi` is `:auto`, which
+    enables the over-the-barrier correction (Zhang et al., 2014) for any atomic species that has
+    tabulated coefficients and is a no-op otherwise; pass `:bsi => :none` to disable it, or
+    `:bsi => :tonglin` to select the Tong & Lin (2005) correction instead.
 - `preionfrac::Float64`: fraction of the gas that is pre-ionised before the pulse. Defaults to `0.0`.
     Note that this is a very simplistic model of pre-ionisation and should be used with
     caution.

--- a/src/Ionisation.jl
+++ b/src/Ionisation.jl
@@ -468,8 +468,9 @@ Create a cached (saved) interpolated PPT ionisation rate function. If a saved lo
 exists, load this rather than recalculate.
 
 # Keyword arguments
-- `N::Int`: Number of samples with which to create the `CSpline` interpolant.
-- `Emax::Number`: Maximum field strength to include in the interpolant.
+- `N::Int`: Number of samples with which to create the `CSpline` interpolant. The samples are
+    log-spaced in field strength from `E_b/2500` to `Emax` (denser at the low-field turn-on).
+- `Emax::Number`: Maximum field strength to include in the interpolant. Defaults to `2 E_b`.
 - `cache::Bool`: Whether to save the pre-calculated rate to a file
 - `cachedir::String`: Path to the directory where the cache should be stored and loaded from.
     Defaults to \$HOME/.luna/pptcache
@@ -504,12 +505,16 @@ function IonRatePPTCached(args...; kwargs...)
     IonRatePPTAccel(args...; cache=true, kwargs...)
 end
 
+# Bump when the cached PPT grid scheme changes, so that stale cache files written with an
+# older grid (same ionpot/λ0/Z/l/N/Emax/kwargs) are not silently reused. v2 = log-spaced grid.
+const PPT_CACHE_VERSION = 2
+
 function IonRatePPTAccel(ionpot::Float64, λ0, Z, l;
     N=2^16, Emax=nothing, cache=true,
     cachedir=joinpath(Utils.cachedir(), "pptcache"),
     stale_age=60 * 10,
     kwargs...)
-    h = hash((ionpot, λ0, Z, l, N, Emax, collect(kwargs)))
+    h = hash((PPT_CACHE_VERSION, ionpot, λ0, Z, l, N, Emax, collect(kwargs)))
     fname = string(h, base=16) * ".h5"
     fpath = joinpath(cachedir, fname)
     if cache && isfile(fpath)
@@ -564,13 +569,22 @@ end
 
 function makePPTcache(ionpot::Float64, λ0, Z, l;
                       N=2^16, Emax=nothing, kwargs...)
-    Emax = isnothing(Emax) ? 2*barrier_suppression(ionpot, Z) : Emax
+    Eb = barrier_suppression(ionpot, Z)
+    Emax = isnothing(Emax) ? 2*Eb : Emax
 
-    # ω0 = 2π*c/λ0
-    # Emin = ω0*sqrt(2m_e*ionpot)/electron/0.5 # Keldysh parameter of 0.5
-    Emin = Emax/5000
+    # Lower bound is tied to the species barrier-suppression field E_b, NOT to Emax, so that
+    # extending Emax into the over-the-barrier regime (e.g. for the :zhang correction) does
+    # not drift the low-field sampling. Eb/2500 reproduces the previous default lower bound
+    # (Emax/5000 evaluated at the default Emax = 2 E_b).
+    Emin = Eb/2500
 
-    E = collect(range(Emin, stop=Emax, length=N));
+    # Geometric (log-spaced) field grid: log(rate) curves sharply at the low-field turn-on and
+    # flattens at high field, so a log grid concentrates samples where the cubic spline needs
+    # them and spends few on the (flat) high-field tail. This preserves low-field resolution
+    # while letting Emax reach ~4.5 E_b (the :zhang validity limit) without increasing N.
+    # Maths.CSpline handles the non-uniform axis via its FastFinder; underflowed (zero) rates
+    # at the very lowest fields are dropped in the IonRatePPTAccel(E, rate) constructor.
+    E = exp10.(range(log10(Emin), log10(Emax); length=N))
     @info @sprintf("Pre-calculating PPT rate for %.2f eV, %.1f nm...", ionpot/electron, 1e9λ0)
     flush(stderr) # pre-calculating can take a while, so make sure this message is shown
     rate = ionrate_PPT(ionpot, λ0, Z, l, E; kwargs...)

--- a/src/Ionisation.jl
+++ b/src/Ionisation.jl
@@ -58,31 +58,39 @@ const ZHANG_COEFFS = Dict{Symbol,NTuple{3,Float64}}(
     bsi_kwargs(material::Symbol, bsi::Symbol)
 
 Resolve the per-species barrier-suppression keyword arguments to forward downstream from a
-Symbol-based constructor. Returns an empty `NamedTuple` for `bsi == :none` so that existing
-cache hashes are unchanged; otherwise returns the tabulated coefficients for `material`.
+Symbol-based constructor, looking up the tabulated coefficients for `material`.
 
-These are static single-active-electron ATOMIC corrections, so a species is accepted only if
-it appears in the relevant coefficient table (`TONGLIN_ALPHA` for `:tonglin`, `ZHANG_COEFFS`
-for `:zhang`) — this is what rejects molecular species, without needing a separate blocklist.
-For an atomic species not in the table, pass `α_bsi`/`zhang_coeffs` explicitly via the raw
-`IonRatePPT(ip, λ0, Z, l; …)` constructor.
+`bsi` is one of:
+- `:auto` (default): enable the correction wherever validated coefficients exist, and silently
+  leave it off otherwise (e.g. molecular or non-tabulated species — no error). `:zhang` is used
+  because it is validated over the widest field range (0.5–4.5 E_b).
+- `:none`: no correction.
+- `:tonglin` / `:zhang`: force that correction; errors if no coefficients are tabulated for
+  `material` (these are single-active-electron ATOMIC corrections, so a species is accepted only
+  if it appears in `TONGLIN_ALPHA` / `ZHANG_COEFFS` — this is what rejects molecular species,
+  without needing a separate blocklist). For an atomic species not in the table, pass
+  `α_bsi`/`zhang_coeffs` explicitly via the raw `IonRatePPT(ip, λ0, Z, l; …)` constructor.
 """
 function bsi_kwargs(material::Symbol, bsi::Symbol)
-    bsi === :none && return (;)
-    if bsi === :tonglin
+    if bsi === :auto
+        return haskey(ZHANG_COEFFS, material) ?
+            (; bsi = :zhang, zhang_coeffs = ZHANG_COEFFS[material]) : (; bsi = :none)
+    elseif bsi === :none
+        return (; bsi = :none)
+    elseif bsi === :tonglin
         haskey(TONGLIN_ALPHA, material) || error(
             "No Tong & Lin (2005) α tabulated for :$material; barrier-suppression " *
             "corrections are defined for atomic species only. Pass α_bsi explicitly via " *
-            "the raw IonRatePPT(ip, λ0, Z, l; …) constructor, or use bsi = :none.")
-        return (; bsi, α_bsi = TONGLIN_ALPHA[material])
+            "the raw IonRatePPT(ip, λ0, Z, l; …) constructor, or use bsi = :auto / :none.")
+        return (; bsi = :tonglin, α_bsi = TONGLIN_ALPHA[material])
     elseif bsi === :zhang
         haskey(ZHANG_COEFFS, material) || error(
             "No Zhang (2014) coefficients tabulated for :$material; barrier-suppression " *
             "corrections are defined for atomic species only. Pass zhang_coeffs explicitly " *
-            "via the raw IonRatePPT(ip, λ0, Z, l; …) constructor, or use bsi = :none.")
-        return (; bsi, zhang_coeffs = ZHANG_COEFFS[material])
+            "via the raw IonRatePPT(ip, λ0, Z, l; …) constructor, or use bsi = :auto / :none.")
+        return (; bsi = :zhang, zhang_coeffs = ZHANG_COEFFS[material])
     else
-        error("Unknown bsi correction: :$bsi. Use :none, :tonglin or :zhang.")
+        error("Unknown bsi correction: :$bsi. Use :auto, :none, :tonglin or :zhang.")
     end
 end
 
@@ -215,17 +223,22 @@ wavelength `λ0`, also given charge state `Z` and angular momentum `l`
     a state with two electrons (spin up/down).
 - `bsi::Symbol`: barrier-suppression (over-the-barrier) correction applied as a multiplicative
     factor to the rate. One of:
-    * `:none`    – no correction (default; original PPT behaviour).
+    * `:auto`    – (default) enable the correction wherever validated coefficients exist for the
+                   species (resolves to `:zhang`), and silently leave it off otherwise (e.g.
+                   molecular/non-tabulated species — no error). Only meaningful when constructing
+                   from a material `Symbol`; the raw `(ip, λ0, Z, l)` constructor treats `:auto`
+                   as `:zhang` if `zhang_coeffs` are supplied, else `:none`.
+    * `:none`    – no correction (original PPT behaviour).
     * `:tonglin` – Tong & Lin, J. Phys. B 38, 2593 (2005), eq. (2):
                    `factor = exp(-α (Z²/Ip)(|E|/κ³))`. Validated to ≈ 2 E_b.
     * `:zhang`   – Zhang, Lan & Lu, Phys. Rev. A 90, 043410 (2014), eq. (8):
                    `factor = exp(a1 u² + a2 u + a3)`, `u = |E|/E_b`. Validated 0.5–4.5 E_b.
-    Both reduce to ≈ 1 well below the barrier-suppression field `E_b = Ip²/(4Z)` and bring the
-    high-field rate into line with single-active-electron TDSE/static results. The factor is
-    clamped to ≤ 1 and (for `:zhang`) `u` is capped at 4.5. These are static (DC) corrections,
-    appropriate for the tunnelling/small-γ regime, not for multiphoton/UV ionisation, and are
-    defined for atomic species only. See the CORRECTNESS NOTE in the source on the sign typo
-    in Zhang eq. (8).
+    Both `:tonglin` and `:zhang` reduce to ≈ 1 well below the barrier-suppression field
+    `E_b = Ip²/(4Z)` and bring the high-field rate into line with single-active-electron
+    TDSE/static results. The factor is clamped to ≤ 1 and (for `:zhang`) `u` is capped at 4.5.
+    These are static (DC) corrections, appropriate for the tunnelling/small-γ regime, not for
+    multiphoton/UV ionisation, and are defined for atomic species only. See the CORRECTNESS
+    NOTE in the source on the sign typo in Zhang eq. (8).
 - `α_bsi::Real`: Tong & Lin α (defaults: per-species table; else 6 for s-wave, 9 otherwise).
 - `zhang_coeffs::NTuple{3,Real}`: `(a1, a2, a3)` for `:zhang` (defaults from the per-species
     table when constructed from a material `Symbol`).
@@ -284,7 +297,7 @@ PPT ionisation rate for the given `material` when driven at wavelength `λ0`.
 
 Other keyword arguments are identical to `IonRatePPT(ionpot::Float64, λ0, Z, l; kwargs...)`
 """
-function IonRatePPT(material::Symbol, λ0; stark_shift=true, dipole_corr=true, bsi::Symbol=:none, kwargs...)
+function IonRatePPT(material::Symbol, λ0; stark_shift=true, dipole_corr=true, bsi::Symbol=:auto, kwargs...)
     _, l, Z = quantum_numbers(material)
     Δα = stark_shift ? polarisability_difference(material) : 0.0
     α_ion = dipole_corr ? polarisability(material, true) : 0.0
@@ -294,7 +307,7 @@ end
 
 function IonRatePPT(ip, λ0, Z, l; Δα=0, α_ion=0, sum_tol=1e-6,
     cycle_average=false, sum_integral=false, msum=true, Cnl=missing, occupancy=2,
-    bsi::Symbol=:none, α_bsi=nothing, zhang_coeffs=nothing)
+    bsi::Symbol=:auto, α_bsi=nothing, zhang_coeffs=nothing)
 
     if ismissing(Δα)
         Δα = 0.0
@@ -309,6 +322,12 @@ function IonRatePPT(ip, λ0, Z, l; Δα=0, α_ion=0, sum_tol=1e-6,
     ω0 = 2π*c/λ0
     ω0_au = au_time*ω0
 
+    # The raw constructor has no species table to consult, so :auto enables :zhang only when
+    # coefficients are supplied, and is otherwise off. (Symbol-based constructors resolve :auto
+    # against the per-species tables before reaching this point — see `bsi_kwargs`.)
+    if bsi === :auto
+        bsi = isnothing(zhang_coeffs) ? :none : :zhang
+    end
     α_bsi_resolved = isnothing(α_bsi) ? tonglin_alpha_default(l) : float(α_bsi)
     zc = isnothing(zhang_coeffs) ? (0.0, 0.0, 0.0) : NTuple{3,Float64}(zhang_coeffs)
     if bsi === :zhang && isnothing(zhang_coeffs)
@@ -316,8 +335,11 @@ function IonRatePPT(ip, λ0, Z, l; Δα=0, α_ion=0, sum_tol=1e-6,
               "species, or pass zhang_coeffs = (a1, a2, a3).")
     end
 
-    IonRatePPT(float(Z), l, Δα, α_ion_au, ω0_au, Cnl, ip, occupancy,
-        msum, sum_integral, sum_tol, cycle_average, bsi, α_bsi_resolved, zc)
+    # Coerce the Float64-typed fields: the raw constructor accepts integer arguments
+    # (e.g. the default Δα=0, or an integer ionpot), but the parametric struct's auto-generated
+    # constructor does not convert them.
+    IonRatePPT(float(Z), l, float(Δα), α_ion_au, ω0_au, Cnl, float(ip), occupancy,
+        msum, sum_integral, float(sum_tol), cycle_average, bsi, α_bsi_resolved, zc)
 end
 
 function (ir::IonRatePPT)(E)
@@ -445,7 +467,7 @@ function ionrate_PPT(ionpot, λ0, Z, l, E; kwargs...)
 end
 
 function ionrate_PPT(material::Symbol, λ0, E;
-                     stark_shift=true, dipole_corr=true, bsi::Symbol=:none, kwargs...)
+                     stark_shift=true, dipole_corr=true, bsi::Symbol=:auto, kwargs...)
     _, l, Z = quantum_numbers(material)
     Δα = stark_shift ? polarisability_difference(material) : 0.0
     α_ion = dipole_corr ? polarisability(material, true) : 0.0
@@ -493,7 +515,7 @@ function IonRatePPTAccel(E, rate)
     IonRatePPTAccel(cspl, Emin, Emax)
 end
 
-function IonRatePPTAccel(material::Symbol, λ0; stark_shift=true, dipole_corr=true, bsi::Symbol=:none, kwargs...)
+function IonRatePPTAccel(material::Symbol, λ0; stark_shift=true, dipole_corr=true, bsi::Symbol=:auto, kwargs...)
     _, l, Z = quantum_numbers(material)
     Δα = stark_shift ? polarisability_difference(material) : 0.0
     α_ion = dipole_corr ? polarisability(material, true) : 0.0

--- a/src/Ionisation.jl
+++ b/src/Ionisation.jl
@@ -12,6 +12,80 @@ import Printf: @sprintf
 
 abstract type AbstractIonRate end
 
+#= ===========================================================================================
+   Barrier-suppression (over-the-barrier) corrections to the PPT rate.
+
+   The PPT/ADK rate is the leading term of a small-field asymptotic expansion and
+   overestimates ionisation near and above the barrier-suppression field
+   E_b = κ⁴/(16 Z) = Ip²/(4Z)  (atomic units),  κ = √(2 Ip).
+   The tables below provide empirical multiplicative correction factors that suppress the
+   rate in this regime, bringing it into line with single-active-electron TDSE / static
+   results. They are ATOMIC corrections (single active electron) and are applied
+   quasistatically to the instantaneous field magnitude |E|.
+=#
+
+# Tong & Lin (2005) J. Phys. B 38, 2593, Table 2: empirical α (≈6 for s-wave, ≈9 for higher l).
+# He = 7.0 is the specific tabulated value (do NOT replace it with the generic 6).
+const TONGLIN_ALPHA = Dict{Symbol,Float64}(
+    :H => 6.0, :He => 7.0, :Ne => 9.0, :Ar => 9.0, :Kr => 9.0, :Xe => 9.0,
+)
+# generic fallback used when a species is not tabulated:
+tonglin_alpha_default(l::Integer) = l == 0 ? 6.0 : 9.0
+
+# Zhang, Lan & Lu (2014) PRA 90, 043410, Table XI: (a1, a2, a3) for
+# factor = exp(a1 u² + a2 u + a3),  u = |E|/E_b.
+#
+# CORRECTNESS NOTE — Zhang, Lan & Lu, PRA 90, 043410 (2014), Eq. (8):
+# As printed, Eq. (8) reads  W_M = exp[ -(a1 u² + a2 u + a3) ] · W_ADK,  u = E/E_b.
+# With the Table XI coefficients this gives a factor > 1 (an ENHANCEMENT) across the whole
+# relevant range, which is unphysical (ADK overestimates, so the factor must be < 1). The
+# printed leading minus sign is a typo; the coefficients are a fit to ln(Γ/W_ADK) (natural
+# log). The correct, physical usage is therefore  factor = exp(a1 u² + a2 u + a3)  with the
+# coefficients used AS PRINTED (no extra minus). Verified two ways: (1) reverse-engineering
+# the factor from the paper's own Ar static rates (Table IX) yields coefficients equal to the
+# printed Table XI values divided by ln(10) — the fingerprint of an ln-space fit; (2) with
+# this form Zhang agrees with Tong & Lin (2005) to <7% for E < 2 E_b, where both are valid.
+const ZHANG_COEFFS = Dict{Symbol,NTuple{3,Float64}}(
+    :H  => ( 0.11714, -0.90933, -0.06034),
+    :He => ( 0.13550, -0.86210,  0.021562),
+    :Ne => ( 0.10061, -1.04832, -0.07542),
+    :Ar => ( 0.16178, -1.50441,  0.32127),
+    :Kr => ( 0.14640, -1.36533,  0.02055),
+    :Xe => ( 0.21080, -1.88482,  0.574281),
+)
+
+"""
+    bsi_kwargs(material::Symbol, bsi::Symbol)
+
+Resolve the per-species barrier-suppression keyword arguments to forward downstream from a
+Symbol-based constructor. Returns an empty `NamedTuple` for `bsi == :none` so that existing
+cache hashes are unchanged; otherwise returns the tabulated coefficients for `material`.
+
+These are static single-active-electron ATOMIC corrections, so a species is accepted only if
+it appears in the relevant coefficient table (`TONGLIN_ALPHA` for `:tonglin`, `ZHANG_COEFFS`
+for `:zhang`) — this is what rejects molecular species, without needing a separate blocklist.
+For an atomic species not in the table, pass `α_bsi`/`zhang_coeffs` explicitly via the raw
+`IonRatePPT(ip, λ0, Z, l; …)` constructor.
+"""
+function bsi_kwargs(material::Symbol, bsi::Symbol)
+    bsi === :none && return (;)
+    if bsi === :tonglin
+        haskey(TONGLIN_ALPHA, material) || error(
+            "No Tong & Lin (2005) α tabulated for :$material; barrier-suppression " *
+            "corrections are defined for atomic species only. Pass α_bsi explicitly via " *
+            "the raw IonRatePPT(ip, λ0, Z, l; …) constructor, or use bsi = :none.")
+        return (; bsi, α_bsi = TONGLIN_ALPHA[material])
+    elseif bsi === :zhang
+        haskey(ZHANG_COEFFS, material) || error(
+            "No Zhang (2014) coefficients tabulated for :$material; barrier-suppression " *
+            "corrections are defined for atomic species only. Pass zhang_coeffs explicitly " *
+            "via the raw IonRatePPT(ip, λ0, Z, l; …) constructor, or use bsi = :none.")
+        return (; bsi, zhang_coeffs = ZHANG_COEFFS[material])
+    else
+        error("Unknown bsi correction: :$bsi. Use :none, :tonglin or :zhang.")
+    end
+end
+
 """
     IonRateADK(ionpot::Float64, threshold=true)
     IonRateADK(material::Symbol)
@@ -139,6 +213,22 @@ wavelength `λ0`, also given charge state `Z` and angular momentum `l`
     the PPT papers.
 - `occupancy`: Occupancy of the state(s) from which ionisation is considered. Defaults to 2 for
     a state with two electrons (spin up/down).
+- `bsi::Symbol`: barrier-suppression (over-the-barrier) correction applied as a multiplicative
+    factor to the rate. One of:
+    * `:none`    – no correction (default; original PPT behaviour).
+    * `:tonglin` – Tong & Lin, J. Phys. B 38, 2593 (2005), eq. (2):
+                   `factor = exp(-α (Z²/Ip)(|E|/κ³))`. Validated to ≈ 2 E_b.
+    * `:zhang`   – Zhang, Lan & Lu, Phys. Rev. A 90, 043410 (2014), eq. (8):
+                   `factor = exp(a1 u² + a2 u + a3)`, `u = |E|/E_b`. Validated 0.5–4.5 E_b.
+    Both reduce to ≈ 1 well below the barrier-suppression field `E_b = Ip²/(4Z)` and bring the
+    high-field rate into line with single-active-electron TDSE/static results. The factor is
+    clamped to ≤ 1 and (for `:zhang`) `u` is capped at 4.5. These are static (DC) corrections,
+    appropriate for the tunnelling/small-γ regime, not for multiphoton/UV ionisation, and are
+    defined for atomic species only. See the CORRECTNESS NOTE in the source on the sign typo
+    in Zhang eq. (8).
+- `α_bsi::Real`: Tong & Lin α (defaults: per-species table; else 6 for s-wave, 9 otherwise).
+- `zhang_coeffs::NTuple{3,Real}`: `(a1, a2, a3)` for `:zhang` (defaults from the per-species
+    table when constructed from a material `Symbol`).
 
 # References
 [1] Ilkov, F. A., Decker, J. E. & Chin, S. L.
@@ -155,6 +245,15 @@ media. Rep. Prog. Phys. 70, 1633–1713 (2007)
 "Femtosecond filamentation in transparent media,"
 Physics Reports 441(2–4), 47–189 (2007).
 
+[4] X. M. Tong and C. D. Lin,
+"Empirical formula for static field ionization rates of atoms and molecules by lasers in
+the barrier-suppression regime,"
+J. Phys. B: At. Mol. Opt. Phys. 38, 2593 (2005).
+
+[5] Q. Zhang, P. Lan, and P. Lu,
+"Empirical formula for over-barrier strong-field ionization,"
+Phys. Rev. A 90, 043410 (2014).
+
 """
 struct IonRatePPT{oT, CT} <: AbstractIonRate
     Z::Float64 # Charge state
@@ -169,6 +268,9 @@ struct IonRatePPT{oT, CT} <: AbstractIonRate
     sum_integral::Bool # replace the infinite sum with an integral?
     sum_tol::Float64 # relative tolerance for convergence of the infinite sum
     cycle_average::Bool # average over one cycle?
+    bsi::Symbol # barrier-suppression correction: :none | :tonglin | :zhang
+    α_bsi::Float64 # Tong & Lin α (used when bsi == :tonglin)
+    zhang_coeffs::NTuple{3,Float64} # (a1, a2, a3) (used when bsi == :zhang)
 end
 
 """
@@ -182,16 +284,17 @@ PPT ionisation rate for the given `material` when driven at wavelength `λ0`.
 
 Other keyword arguments are identical to `IonRatePPT(ionpot::Float64, λ0, Z, l; kwargs...)`
 """
-function IonRatePPT(material::Symbol, λ0; stark_shift=true, dipole_corr=true, kwargs...)
+function IonRatePPT(material::Symbol, λ0; stark_shift=true, dipole_corr=true, bsi::Symbol=:none, kwargs...)
     _, l, Z = quantum_numbers(material)
     Δα = stark_shift ? polarisability_difference(material) : 0.0
     α_ion = dipole_corr ? polarisability(material, true) : 0.0
     ip = ionisation_potential(material)
-    IonRatePPT(ip, λ0, float(Z), l; Δα, α_ion, kwargs...)
+    IonRatePPT(ip, λ0, float(Z), l; Δα, α_ion, bsi_kwargs(material, bsi)..., kwargs...)
 end
 
 function IonRatePPT(ip, λ0, Z, l; Δα=0, α_ion=0, sum_tol=1e-6,
-    cycle_average=false, sum_integral=false, msum=true, Cnl=missing, occupancy=2)
+    cycle_average=false, sum_integral=false, msum=true, Cnl=missing, occupancy=2,
+    bsi::Symbol=:none, α_bsi=nothing, zhang_coeffs=nothing)
 
     if ismissing(Δα)
         Δα = 0.0
@@ -206,8 +309,15 @@ function IonRatePPT(ip, λ0, Z, l; Δα=0, α_ion=0, sum_tol=1e-6,
     ω0 = 2π*c/λ0
     ω0_au = au_time*ω0
 
+    α_bsi_resolved = isnothing(α_bsi) ? tonglin_alpha_default(l) : float(α_bsi)
+    zc = isnothing(zhang_coeffs) ? (0.0, 0.0, 0.0) : NTuple{3,Float64}(zhang_coeffs)
+    if bsi === :zhang && isnothing(zhang_coeffs)
+        error("bsi = :zhang requires `zhang_coeffs`; construct from a Symbol for a tabulated " *
+              "species, or pass zhang_coeffs = (a1, a2, a3).")
+    end
+
     IonRatePPT(float(Z), l, Δα, α_ion_au, ω0_au, Cnl, ip, occupancy,
-        msum, sum_integral, sum_tol, cycle_average)
+        msum, sum_integral, sum_tol, cycle_average, bsi, α_bsi_resolved, zc)
 end
 
 function (ir::IonRatePPT)(E)
@@ -264,6 +374,26 @@ function (ir::IonRatePPT)(E)
     if ir.α_ion_au ≠ 0
         ret *= exp(-2*ir.α_ion_au*E_au)
     end
+    # --- Barrier-suppression / over-the-barrier correction ---------------------
+    # Tong & Lin, J. Phys. B 38, 2593 (2005), eq. (2) [4]; or
+    # Zhang, Lan & Lu, Phys. Rev. A 90, 043410 (2014), eq. (8) [5] [see CORRECTNESS NOTE].
+    # E_b and κ use the FIELD-FREE Ip (not the Stark-shifted Ip_au above).
+    if ir.bsi !== :none
+        Ip0_au = ir.ionpot / au_energy
+        κ0     = sqrt(2 * Ip0_au)
+        Eb_au  = κ0^4 / (16 * ir.Z)                 # = Ip0²/(4Z); barrier-suppression field
+        if ir.bsi === :tonglin
+            f = exp(-ir.α_bsi * (ir.Z^2 / Ip0_au) * (E_au / κ0^3))
+        elseif ir.bsi === :zhang
+            u = min(E_au / Eb_au, 4.5)              # Zhang fit validated only to 4.5 E_b
+            a1, a2, a3 = ir.zhang_coeffs
+            f = exp(a1*u^2 + a2*u + a3)
+        else
+            error("Unknown bsi correction: $(ir.bsi). Use :none, :tonglin or :zhang.")
+        end
+        ret *= min(f, 1.0)                          # never enhance the rate
+    end
+    # ---------------------------------------------------------------------------
     return ret/au_time
 end
 
@@ -315,12 +445,12 @@ function ionrate_PPT(ionpot, λ0, Z, l, E; kwargs...)
 end
 
 function ionrate_PPT(material::Symbol, λ0, E;
-                     stark_shift=true, dipole_corr=true, kwargs...)
+                     stark_shift=true, dipole_corr=true, bsi::Symbol=:none, kwargs...)
     _, l, Z = quantum_numbers(material)
     Δα = stark_shift ? polarisability_difference(material) : 0.0
     α_ion = dipole_corr ? polarisability(material, true) : 0.0
     ip = ionisation_potential(material)
-    return ionrate_PPT(ip, λ0, Z, l, E; Δα, α_ion, kwargs...)
+    return ionrate_PPT(ip, λ0, Z, l, E; Δα, α_ion, bsi_kwargs(material, bsi)..., kwargs...)
 end
 
 struct IonRatePPTAccel{ST} <: AbstractIonRate
@@ -344,7 +474,10 @@ exists, load this rather than recalculate.
 - `cachedir::String`: Path to the directory where the cache should be stored and loaded from.
     Defaults to \$HOME/.luna/pptcache
 
-Other keyword arguments are passed on to [`IonRatePPT`](@ref)
+Other keyword arguments (including the barrier-suppression `bsi` correction) are passed on to
+[`IonRatePPT`](@ref). Note that when a `bsi` correction is enabled `Emax` should be set to at
+least the expected peak field, since it otherwise defaults to `2 E_b`; the `:zhang` correction
+is validated up to ≈ `4.5 E_b`. Cache filenames already distinguish the `bsi` setting.
 """
 function IonRatePPTAccel(E, rate)
     # first remove points where the rate is zero within floating-point
@@ -359,12 +492,12 @@ function IonRatePPTAccel(E, rate)
     IonRatePPTAccel(cspl, Emin, Emax)
 end
 
-function IonRatePPTAccel(material::Symbol, λ0; stark_shift=true, dipole_corr=true, kwargs...)
+function IonRatePPTAccel(material::Symbol, λ0; stark_shift=true, dipole_corr=true, bsi::Symbol=:none, kwargs...)
     _, l, Z = quantum_numbers(material)
     Δα = stark_shift ? polarisability_difference(material) : 0.0
     α_ion = dipole_corr ? polarisability(material, true) : 0.0
     ip = ionisation_potential(material)
-    IonRatePPTAccel(ip, λ0, Z, l; Δα, α_ion, kwargs...)
+    IonRatePPTAccel(ip, λ0, Z, l; Δα, α_ion, bsi_kwargs(material, bsi)..., kwargs...)
 end
 
 function IonRatePPTCached(args...; kwargs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,6 +38,11 @@ end
     include(joinpath(testdir, "test_ionisation.jl"))
 end
 
+@testset "Ionisation BSI" begin
+    @info("================= test_ionisation_bsi.jl")
+    include(joinpath(testdir, "test_ionisation_bsi.jl"))
+end
+
 @testset "Output" begin
     @info("================= test_output.jl")
     include(joinpath(testdir, "test_output.jl"))

--- a/test/test_ionisation.jl
+++ b/test/test_ionisation.jl
@@ -12,8 +12,8 @@ import Logging: with_logger, NullLogger
 E = collect(range(1e9, 1e11; length=32))
 @test Ionisation.ionrate_ADK(:He, E) == Ionisation.ionrate_ADK(:He, -E)
 
-@test isapprox(Ionisation.ionrate_PPT(:He, 800e-9, 1e10; dipole_corr=false), 2*1.40432138471583e-5, rtol=1e-3)
-@test isapprox(Ionisation.ionrate_PPT(:He, 800e-9, 1.3e10; dipole_corr=false), 2*0.04517809797503506, rtol=1e-3)
+@test isapprox(Ionisation.ionrate_PPT(:He, 800e-9, 1e10; dipole_corr=false, bsi=:none), 2*1.40432138471583e-5, rtol=1e-3)
+@test isapprox(Ionisation.ionrate_PPT(:He, 800e-9, 1.3e10; dipole_corr=false, bsi=:none), 2*0.04517809797503506, rtol=1e-3)
 
 Emin = 1e9
 Emax = 1e11

--- a/test/test_ionisation_bsi.jl
+++ b/test/test_ionisation_bsi.jl
@@ -1,0 +1,94 @@
+import Test: @test, @testset, @test_throws
+using Luna
+import Luna.PhysData: au_Efield
+
+# Tests for the barrier-suppression (over-the-barrier) corrections to the PPT rate.
+#
+# Expected behaviour (He @ 800 nm is the primary case):
+#  - `:none` reproduces the current PPT rate exactly (regression guard).
+#  - The correction factor is ≈ 1 (within a few %) far below E_b, then falls below 1 as the
+#    field approaches and exceeds E_b ≈ 0.204 a.u. (1.05e11 V/m) for He.
+#  - At E_b: Tong–Lin → 0.52×, Zhang → 0.49× the bare rate.
+#  - Tong–Lin and Zhang coincide to <10% for E < 2 E_b (their common validity region). If
+#    this test fails, suspect a wrong/sign-flipped Zhang coefficient or the Eq. (8) typo.
+#  - Above 2 E_b they diverge: Tong–Lin keeps suppressing (its corrected rate eventually
+#    turns over and decreases with field — unphysical), while Zhang flattens and the rate
+#    keeps rising. Hence `zh > tl` beyond ~2 E_b.
+
+@testset "PPT barrier-suppression corrections" begin
+    λ0 = 800e-9
+    Ip = PhysData.ionisation_potential(:He)
+    Ip_au = Ip / PhysData.au_energy
+    Z = 1.0
+    κ  = sqrt(2Ip_au)
+    Eb_au = Ip_au^2 / (4Z)              # = 0.204 a.u.
+    Eb = Eb_au * au_Efield              # field in V/m
+
+    none = Ionisation.IonRatePPT(:He, λ0; bsi=:none)
+    tl   = Ionisation.IonRatePPT(:He, λ0; bsi=:tonglin)
+    zh   = Ionisation.IonRatePPT(:He, λ0; bsi=:zhang)
+
+    factor(rate, E) = rate(E) / none(E)
+
+    # (a) Regression: :none must equal the unmodified PPT exactly.
+    for x in (0.3, 0.8, 1.5)
+        @test none(x*Eb) == Ionisation.IonRatePPT(:He, λ0)(x*Eb)
+    end
+
+    # (b) Mild correction well below E_b (factor close to 1).
+    @test 0.88 ≤ factor(tl, 0.15Eb) ≤ 1.0
+    @test 0.88 ≤ factor(zh, 0.15Eb) ≤ 1.0
+
+    # (c) Known He values at the barrier-suppression field E_b.
+    @test isapprox(factor(tl, Eb), 0.522; atol=0.01)   # Tong–Lin α=7
+    @test isapprox(factor(zh, Eb), 0.494; atol=0.01)   # Zhang
+
+    # (d) Tong–Lin and Zhang must AGREE below ~2 E_b (the overlap of their validity).
+    for x in (0.5, 0.8, 1.0, 1.3, 1.8)
+        @test isapprox(tl(x*Eb), zh(x*Eb); rtol=0.10)
+    end
+
+    # (e) Both must SUPPRESS (never enhance) over the whole range; factor ≤ 1.
+    for x in (0.2, 0.5, 1.0, 2.0, 3.0, 4.5)
+        @test factor(tl, x*Eb) ≤ 1.0 + 1e-9
+        @test factor(zh, x*Eb) ≤ 1.0 + 1e-9
+        @test tl(x*Eb) ≤ none(x*Eb)
+        @test zh(x*Eb) ≤ none(x*Eb)
+    end
+
+    # (f) Beyond 2 E_b, Tong–Lin over-suppresses → Zhang gives the LARGER (more physical) rate.
+    for x in (2.5, 3.0, 4.0)
+        @test zh(x*Eb) > tl(x*Eb)
+    end
+
+    # (g) Independent self-consistency of the Tong–Lin analytic factor.
+    αHe = 7.0
+    f_expected = exp(-αHe * (Z^2/Ip_au) * (Eb_au/κ^3))
+    @test isapprox(factor(tl, Eb), f_expected; rtol=1e-6)
+
+    # (h) Zhang argument is capped at 4.5 E_b (factor frozen beyond).
+    @test isapprox(factor(zh, 5.0Eb), factor(zh, 4.5Eb); rtol=1e-6)
+
+    # (i) Unknown-species guard for :zhang via raw-ip constructor (no coefficients given).
+    @test_throws ErrorException Ionisation.IonRatePPT(Ip, λ0, Z, 0; bsi=:zhang)
+
+    # (extra) Molecular species must be rejected for any correction.
+    @test_throws ErrorException Ionisation.IonRatePPT(:N2, λ0; bsi=:tonglin)
+    @test_throws ErrorException Ionisation.IonRatePPT(:O2, λ0; bsi=:zhang)
+    @test_throws ErrorException Ionisation.ionrate_PPT(:N2, λ0, Eb; bsi=:tonglin)
+    @test_throws ErrorException Ionisation.IonRatePPTAccel(:O2, λ0; cache=false, bsi=:tonglin)
+
+    # (j) The correction must propagate through the accelerated/cached rate path, and the
+    #     three settings must yield different interpolants (→ different cache files).
+    #     cache=false avoids polluting the cache dir; Emax covers the tested fields.
+    Emax = 4.5Eb
+    acc_none = Ionisation.IonRatePPTAccel(:He, λ0; cache=false, bsi=:none, Emax)
+    acc_tl   = Ionisation.IonRatePPTAccel(:He, λ0; cache=false, bsi=:tonglin, Emax)
+    acc_zh   = Ionisation.IonRatePPTAccel(:He, λ0; cache=false, bsi=:zhang, Emax)
+    @test acc_tl.spline.y != acc_none.spline.y
+    @test acc_zh.spline.y != acc_none.spline.y
+    @test acc_tl.spline.y != acc_zh.spline.y
+    # accelerated correction roughly matches the direct functor at E_b
+    @test isapprox(acc_tl(Eb), tl(Eb); rtol=1e-2)
+    @test isapprox(acc_zh(Eb), zh(Eb); rtol=1e-2)
+end

--- a/test/test_ionisation_bsi.jl
+++ b/test/test_ionisation_bsi.jl
@@ -98,3 +98,62 @@ import Luna.PhysData: au_Efield
     @test isapprox(acc_tl(Eb), tl(Eb); rtol=1e-2)
     @test isapprox(acc_zh(Eb), zh(Eb); rtol=1e-2)
 end
+
+# Sanity checks for the other tabulated noble gases. These mirror the He checks but avoid the
+# He-specific hardcoded factor values. The key guard remains the Tong–Lin ↔ Zhang agreement
+# below ~2 E_b: a wrong/sign-flipped Zhang coefficient (or the eq. (8) typo) would push the
+# Zhang factor above 1 and break it. The agreement is looser than for He — the paper documents
+# ~10–25% (Zhang gives slightly weaker suppression) for Ne/Kr/Xe — so rtol is relaxed to 0.3.
+@testset "PPT barrier-suppression sanity: $gas" for gas in (:Ne, :Ar, :Kr, :Xe)
+    λ0 = 800e-9
+    Ip = PhysData.ionisation_potential(gas)
+    Ip_au = Ip / PhysData.au_energy
+    _, l, Zq = PhysData.quantum_numbers(gas)
+    Z = float(Zq)
+    κ = sqrt(2Ip_au)
+    Eb_au = Ip_au^2 / (4Z)
+    Eb = Eb_au * au_Efield
+
+    none = Ionisation.IonRatePPT(gas, λ0; bsi=:none)
+    tl   = Ionisation.IonRatePPT(gas, λ0; bsi=:tonglin)
+    zh   = Ionisation.IonRatePPT(gas, λ0; bsi=:zhang)
+    factor(rate, E) = rate(E) / none(E)
+
+    # default :auto resolves to :zhang for these tabulated atomic gases
+    @test Ionisation.IonRatePPT(gas, λ0).bsi == :zhang
+    @test Ionisation.IonRatePPT(gas, λ0; bsi=:auto).zhang_coeffs == Ionisation.ZHANG_COEFFS[gas]
+
+    # (b) mild correction well below E_b (factor not far from 1).
+    @test 0.75 ≤ factor(tl, 0.15Eb) ≤ 1.0
+    @test 0.75 ≤ factor(zh, 0.15Eb) ≤ 1.0
+
+    # (c) moderate suppression at E_b (loose, gas-independent bounds).
+    @test 0.2 ≤ factor(tl, Eb) ≤ 0.7
+    @test 0.2 ≤ factor(zh, Eb) ≤ 0.7
+
+    # (d) Tong–Lin and Zhang must AGREE below ~2 E_b (sign-typo guard).
+    for x in (0.5, 0.8, 1.0, 1.3, 1.8)
+        @test isapprox(tl(x*Eb), zh(x*Eb); rtol=0.3)
+    end
+
+    # (e) both must SUPPRESS (never enhance) over the whole range; factor ≤ 1.
+    for x in (0.2, 0.5, 1.0, 2.0, 3.0, 4.5)
+        @test factor(tl, x*Eb) ≤ 1.0 + 1e-9
+        @test factor(zh, x*Eb) ≤ 1.0 + 1e-9
+        @test tl(x*Eb) ≤ none(x*Eb)
+        @test zh(x*Eb) ≤ none(x*Eb)
+    end
+
+    # (f) Beyond 2 E_b, Tong–Lin over-suppresses → Zhang gives the LARGER (more physical) rate.
+    for x in (2.5, 3.0, 4.0)
+        @test zh(x*Eb) > tl(x*Eb)
+    end
+
+    # (g) Independent self-consistency of the Tong–Lin analytic factor with the tabulated α.
+    α = Ionisation.TONGLIN_ALPHA[gas]
+    f_expected = exp(-α * (Z^2/Ip_au) * (Eb_au/κ^3))
+    @test isapprox(factor(tl, Eb), f_expected; rtol=1e-6)
+
+    # (h) Zhang argument is capped at 4.5 E_b (factor frozen beyond).
+    @test isapprox(factor(zh, 5.0Eb), factor(zh, 4.5Eb); rtol=1e-6)
+end

--- a/test/test_ionisation_bsi.jl
+++ b/test/test_ionisation_bsi.jl
@@ -30,9 +30,15 @@ import Luna.PhysData: au_Efield
 
     factor(rate, E) = rate(E) / none(E)
 
-    # (a) Regression: :none must equal the unmodified PPT exactly.
+    # (a) :auto (the new default) enables :zhang where coefficients exist, and is off otherwise.
+    @test Ionisation.IonRatePPT(:He, λ0).bsi == :zhang            # default is :auto → :zhang
+    @test Ionisation.IonRatePPT(:He, λ0; bsi=:auto).bsi == :zhang
+    @test Ionisation.IonRatePPT(:He, λ0; bsi=:auto).zhang_coeffs == Ionisation.ZHANG_COEFFS[:He]
+    @test Ionisation.IonRatePPT(:N2, λ0; bsi=:auto).bsi == :none  # molecular → off, no error
+    @test Ionisation.IonRatePPT(:He, λ0; bsi=:none).bsi == :none
     for x in (0.3, 0.8, 1.5)
-        @test none(x*Eb) == Ionisation.IonRatePPT(:He, λ0)(x*Eb)
+        @test Ionisation.IonRatePPT(:He, λ0)(x*Eb) == zh(x*Eb)   # default matches explicit :zhang
+        @test none(x*Eb) ≥ zh(x*Eb)                              # :none is the uncorrected rate
     end
 
     # (b) Mild correction well below E_b (factor close to 1).


### PR DESCRIPTION
This pull request introduces support for barrier-suppression (over-the-barrier) corrections to the PPT ionisation rate.

Note this also changes the ionisation cache to be log spaced.