### PR TITLE
docs: fix 3 typos in code strings and comments

### DIFF
--- a/src/RectModes.jl
+++ b/src/RectModes.jl
@@ -39,7 +39,7 @@ RectMode(a::Number, args...; kwargs...) = RectMode(z->a, args...; kwargs...)
 RectMode(afun, b::Number, args...; kwargs...) = RectMode(afun, z->b, args...; kwargs...)
 RectMode(a::Number, b::Number, args...; kwargs...) = RectMode(z->a, z->b, args...; kwargs...)
 
-"convenience constructor assunming single gas filling and specified cladding"
+"convenience constructor assuming single gas filling and specified cladding"
 function RectMode(afun, bfun, gas, P, clad; n=1, m=1, pol=:x, T=roomtemp)
     rfg = ref_index_fun(gas, P, T)
     rfs = ref_index_fun(clad)

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -25,7 +25,7 @@ function git_commit()
         LibGit2.isdirty(repo) && (commit *= " (dirty)")
         return commit
     catch
-        "unavailable (Luna is not checkout out for development)"
+        "unavailable (Luna is not checked out for development)"
     end
 end
 
@@ -36,7 +36,7 @@ function git_branch()
         branch = split(n, "/")[end]
         return branch
     catch
-        "unavailable (Luna is not checkout out for development)"
+        "unavailable (Luna is not checked out for development)"
     end
 end
 


### PR DESCRIPTION
## Summary

Fix 3 spelling errors across 2 Julia files:

- **src/Utils.jl**: "checkout out" → "checked out" (×2, error message strings)
- **src/RectModes.jl**: "assunming" → "assuming" (docstring)

**Note:** The Utils.jl fixes change error message text, which could affect log parsing.