### PR TITLE
Fix DataField(fpath) silently dropping the λ0 keyword

### DIFF
--- a/src/Fields.jl
+++ b/src/Fields.jl
@@ -233,7 +233,7 @@ contain 3 columns:
 """
 function DataField(fpath; energy, ϕ=Float64[], λ0=NaN)
     dat = readdlm(fpath, ' ')
-    DataField(dat[:, 1]*2π, dat[:, 2], dat[:, 3]; energy, ϕ)
+    DataField(dat[:, 1]*2π, dat[:, 2], dat[:, 3]; energy, ϕ, λ0)
 end
 
 """


### PR DESCRIPTION
## Summary
- `DataField(fpath; energy, ϕ=Float64[], λ0=NaN)` accepts `λ0` but never forwards it to the inner 3-array constructor call, so a caller loading a spectrum from file and explicitly passing `λ0` has it silently discarded.
- The field then falls back to auto-detecting `λ0` from the spectral moment (`(d::DataField)(grid, FT)`'s `isnan(d.λ0) ? wlfreq(moment(...)) : d.λ0`), which can differ meaningfully from the intended reference wavelength for an asymmetric or multi-peaked spectrum.
- The other two `DataField` constructors (from `ω`/`Iω`/`ϕω` arrays, and from `ω`/`Eω`) already forward `λ0` correctly — this brings the file-loading constructor in line with them.

## Fix
One-line change: forward `λ0` in the inner constructor call.

## Test plan
- [x] Confirmed by reading `(d::DataField)(grid, FT)`'s fallback logic that a caller-supplied `λ0` was being silently ignored for the file-loading constructor only.
- [ ] Would appreciate a maintainer sanity-check against any existing `DataField(fpath; ...)` usage/tests in this repo.