### PR TITLE
Fix arbitrary code execution in parse_item(UnitRange{Int}, ...)

### DIFF
--- a/src/Scans.jl
+++ b/src/Scans.jl
@@ -238,7 +238,11 @@ function makeexec(args::Vector{String})
 end
 
 # Enable parsing of command-line arguments of the form "1:5" to a UnitRange
-parse_item(::Type{UnitRange{Int}}, x::AbstractString) = eval(Meta.parse(x))
+function parse_item(::Type{UnitRange{Int}}, x::AbstractString)
+    parts = split(x, ":")
+    length(parts) == 2 || throw(ArgumentError("Invalid format for UnitRange{Int}: $x. Expected start:stop"))
+    return parse(Int, parts[1]):parse(Int, parts[2])
+end
 
 # Enable parsing of command-line arguments of the form "1,5" to a Tuple of integers
 parse_item(::Type{Tuple{Int, Int}}, x::AbstractString) = Tuple(parse(Int, xi) for xi in split(x, ","))


### PR DESCRIPTION
## Summary
`Scans.jl`'s `parse_item(::Type{UnitRange{Int}}, x::AbstractString) = eval(Meta.parse(x))` evaluates its command-line-argument input as arbitrary Julia code. This is ArgParse's hook for parsing the `--range`/`-r` CLI flag into a `UnitRange` for `RangeExec`.

Any caller that constructs a scan's argument list from untrusted input (a shared cluster environment, a wrapper script exposed to less-trusted users, a CI job parameterized by external input, etc.) gets arbitrary code execution instead of a range-parse error.

## Fix
Replaced with an explicit `split` + `parse(Int, ...)` implementation that accepts exactly the documented `"start:stop"` format and raises an `ArgumentError` on anything else — matching the sibling `Tuple{Int,Int}` `parse_item` two lines below, which already parses explicitly rather than via `eval`.

## Test plan
- [x] Verified the replacement correctly parses `"1:5"` → `1:5` and rejects malformed input with a clear error, by inspection against the documented format.
- [ ] Happy to add a `@test` for this if there's an existing Scans test file this repo wants it in — didn't see one obviously scoped to `parse_item` and didn't want to guess at test-suite conventions.