### PR TITLE
Fix remote command injection in SSHExec's SSH/SCP submission

### DIFF
--- a/src/Scans.jl
+++ b/src/Scans.jl
@@ -528,18 +528,31 @@ function runscan(f, scan::Scan{<:SSHExec})
         scriptfile = basename(script)
         name = scan.name
         folder = Dates.format(Dates.now(), "yyyymmdd_HHMMSS") * "_$name"
-        @info "Making directory \$HOME/$subdir/$folder"
-        read(`ssh $host "mkdir -p \$HOME/$subdir/$folder"`)
+
+        # subdir/folder/scriptfile end up as literal text inside a command string
+        # that ssh hands to the remote shell for interpretation, and scp's
+        # host:path argument is parsed by scp's own shell-like splitting -
+        # shell-escape each component before splicing it in, and use the Cmd
+        # array constructor (not a raw backtick with a bare $host), so a
+        # scan name or subdir containing shell metacharacters can't inject
+        # commands into the remote shell.
+        subdir_esc = Base.shell_escape_posixly(subdir)
+        folder_esc = Base.shell_escape_posixly(folder)
+        scriptfile_esc = Base.shell_escape_posixly(scriptfile)
+        remotedir = "\$HOME/$subdir_esc/$folder_esc"
+
+        @info "Making directory $remotedir"
+        read(Cmd(["ssh", host, "mkdir -p $remotedir"]))
         @info "Transferring file..."
-        read(`scp $script $host:\~/$subdir/$folder`)
+        read(Cmd(["scp", script, "$host:$remotedir"]))
         if length(scan.exec.files) > 0
             @info "Transferring auxiliary files..."
             for fi in scan.exec.files
-                read(`scp $fi $host:\~/$subdir/$folder`)
+                read(Cmd(["scp", fi, "$host:$remotedir"]))
             end
         end
         @info "Running Luna script on remote host $host"
-        read(`ssh $host julia \$HOME/$subdir/$folder/$scriptfile`, String)
+        read(Cmd(["ssh", host, "julia", "$remotedir/$scriptfile_esc"]), String)
     end
 end
 


### PR DESCRIPTION
## Summary
`runscan(::Scan{<:SSHExec})` splices the scan name, configured subdirectory, and script basename unescaped into a command string that gets handed to the remote host's shell (via ssh's "run this string" argument) and into scp's `host:path` argument (parsed by scp's own shell-like splitting).

A scan name or configured subdir containing shell metacharacters (backticks, semicolons, `$()`, quotes) is executed on the remote host rather than treated as a literal path component. Since scan names are often built programmatically (e.g. from a parameter sweep, a timestamp plus a user-supplied label, or driven by external input), this is a genuine remote command injection into whatever host `SSHExec` is configured to submit to.

## Fix
- Shell-escape each user-influenced path component (`subdir`, `folder`, `scriptfile`) with `Base.shell_escape_posixly` before splicing them into the remote command string.
- Switch from a raw backtick command (`` `ssh $host "..."` ``) to the `Cmd` array constructor (`Cmd(["ssh", host, "..."])`) so local argument boundaries are unambiguous — `host` can no longer be interpreted as extra shell syntax on the local side either.

Behavior for well-formed scan names/subdirs (the common case) is unchanged.

## Test plan
- [x] Verified by inspection that `Base.shell_escape_posixly` correctly neutralizes shell metacharacters in a path component destined for both `sh -c`-style remote execution (via ssh) and scp's path parsing.
- [ ] I don't have a spare SSH-reachable host to exercise the actual submission path end-to-end against a real remote — a maintainer with a test SSH target may want to double-check the `mkdir`/`scp`/remote `julia` invocation still succeeds for a normal (non-adversarial) scan name.