### PR TITLE
change getφ spelling to make it easier

### DIFF
--- a/src/Fields.jl
+++ b/src/Fields.jl
@@ -138,7 +138,7 @@ function (p::PulseField)(grid, FT)
         Pt = It(Et, grid)
         Et .*= sqrt(p.power)/sqrt(maximum(Pt))
     end
-        
+
     FT * Et
 end
 
@@ -233,7 +233,7 @@ contain 3 columns:
 """
 function DataField(fpath; energy, ϕ=Float64[], λ0=NaN)
     dat = readdlm(fpath, ' ')
-    DataField(dat[:, 1]*2π, dat[:, 2], dat[:, 3]; energy, ϕ)
+    DataField(dat[:, 1]*2π, dat[:, 2], dat[:, 3]; energy, ϕ, λ0)
 end
 
 """
@@ -525,7 +525,7 @@ function int2D(field1, field2, lowerlim, upperlim)
     end
     val
 end
-    
+
 function normalised_field(fieldfunc, rmax)
     scale = 1.0/sqrt(int2D(fieldfunc, fieldfunc, (0.0, 0.0), (rmax, 2π)))
     return let scale=scale, fieldfunc=fieldfunc
@@ -543,7 +543,7 @@ end
     coupled_field(i, mode, E, fieldfunc; energy, kwargs...)
 
 Create an element of an input field tuple (for use in `Luna.setup`) based on coupling
-field `E` into a `mode`. The index `i` species the mode index. The temporal fields are 
+field `E` into a `mode`. The index `i` species the mode index. The temporal fields are
 initialised using `fieldfunc` (e.g. one of `GaussField`, `SechField` etc.) with the
 same keyword arguments.
 """
@@ -648,7 +648,7 @@ function energyfuncs(grid::Grid.RealGrid, xygrid::Grid.FreeGrid)
     prefac_t = PhysData.c*PhysData.ε_0/2 * δx * δy * δt
     function energy_t(Et)
         Eta = Maths.hilbert(Et)
-        return  prefac_t * sum(abs2.(Eta)) 
+        return  prefac_t * sum(abs2.(Eta))
     end
 
     δω = grid.ω[2] - grid.ω[1]
@@ -669,7 +669,7 @@ function energyfuncs(grid::Grid.EnvGrid, xygrid::Grid.FreeGrid)
     δt = grid.t[2] - grid.t[1]
     prefac_t = PhysData.c*PhysData.ε_0/2 * δx * δy * δt
     function energy_t(Et)
-        return  prefac_t * sum(abs2.(Et)) 
+        return  prefac_t * sum(abs2.(Et))
     end
 
     δω = grid.ω[2] - grid.ω[1]
@@ -854,7 +854,7 @@ prop_mode(Eω, args...) = prop_mode!(copy(Eω), args...)
     optcomp_taylor(Eω, grid, λ0; order=2)
 
 Maximise the peak power of the field `Eω` by adding Taylor-expanded spectral phases up to
-order `order`. 
+order `order`.
 """
 function optcomp_taylor(Eω::AbstractVecOrMat, grid, λ0; order=2, boundfac=8)
     τ = length(grid.t) * (grid.t[2] - grid.t[1])/2
@@ -904,7 +904,7 @@ _It(Et::AbstractMatrix, grid) = dropdims(sum(It(Et, grid); dims=2); dims=2)
 """
     optcomp_material(Eω, grid, material, λ0; kwargs...)
 
-Maximise the peak power of the field `Eω` by linear propagation through the `material`. 
+Maximise the peak power of the field `Eω` by linear propagation through the `material`.
 Keyword arguments `kwargs` are the same as for [`prop_material`](@ref).
 """
 function optcomp_material(Eω::AbstractVecOrMat, grid, material, λ0,

--- a/src/Fields.jl
+++ b/src/Fields.jl
@@ -543,7 +543,7 @@ end
     coupled_field(i, mode, E, fieldfunc; energy, kwargs...)
 
 Create an element of an input field tuple (for use in `Luna.setup`) based on coupling
-field `E` into a `mode`. The index `i` species the mode index. The temporal fields are
+field `E` into a `mode`. The index `i` specifies the mode index. The temporal fields are
 initialised using `fieldfunc` (e.g. one of `GaussField`, `SechField` etc.) with the
 same keyword arguments.
 """

--- a/src/Processing.jl
+++ b/src/Processing.jl
@@ -596,7 +596,7 @@ end
     getEω(output[, zslice])
 
 Get frequency-domain modal field from `output` with correct normalisation (i.e.
-`abs2.(Eω)`` gives angular-frequency spectral energy density in J/(rad/s)).
+`abs2.(Eω)` gives angular-frequency spectral energy density in J/(rad/s)).
 """
 getEω(output::AbstractOutput, args...) = getEω(makegrid(output), output, args...)
 getEω(grid, output) = getEω(grid, output["Eω"])

--- a/src/Processing.jl
+++ b/src/Processing.jl
@@ -659,6 +659,8 @@ function spectral_phase(output, args...)
     spectral_phase(ω, Eω, τ)
 end
 
+Base.@deprecate getφ(args...) spectral_phase(args...) false
+
 """
     getEt(output[, zslice]; kwargs...)
 

--- a/src/Processing.jl
+++ b/src/Processing.jl
@@ -247,7 +247,7 @@ end
     time_bandwidth(grid, Eω; bandpass=nothing, oversampling=1)
 
 Extract the time-bandwidth product, after bandpassing if required. The TBP
-is defined here as ΔfΔt where Δx is the FWHM of x. (In this definition, the TBP of 
+is defined here as ΔfΔt where Δx is the FWHM of x. (In this definition, the TBP of
 a perfect Gaussian pulse is ≈0.44). If `oversampling` > 1, the time-domain field is
 oversampled before extracting the FWHM.
 """
@@ -595,7 +595,7 @@ end
 """
     getEω(output[, zslice])
 
-Get frequency-domain modal field from `output` with correct normalisation (i.e. 
+Get frequency-domain modal field from `output` with correct normalisation (i.e.
 `abs2.(Eω)`` gives angular-frequency spectral energy density in J/(rad/s)).
 """
 getEω(output::AbstractOutput, args...) = getEω(makegrid(output), output, args...)
@@ -626,37 +626,37 @@ fftnorm(grid::EnvGrid) = Maths.fftnorm(grid.t[2] - grid.t[1])
 
 
 """
-    getφ(grid, Eω)
-    getφ(ω, Eω, τ)
+    spectral_phase(grid, Eω)
+    spectral_phase(ω, Eω, τ)
 
 Extract the unwrapped spectral phase from the field `Eω`, subtracting the linear phase ramp corresponding
-to a pulse in the middle of the time window defined by the `grid`. 
+to a pulse in the middle of the time window defined by the `grid`.
 """
-function getφ(grid::AbstractGrid, Eω)
+function spectral_phase(grid::AbstractGrid, Eω)
     ω = grid.ω
     t = grid.t
     τ = length(t) * (t[2] - t[1])/2 # middle of time window
-    getφ(ω, Eω, τ)
+    spectral_phase(ω, Eω, τ)
 end
 
-function getφ(ω::AbstractVector, Eω, τ)
+function spectral_phase(ω::AbstractVector, Eω, τ)
     φ = unwrap(angle.(Eω); dims=1)
     φ .- ω*τ
 end
 
 """
-    getφ(output, args...)
+    spectral_phase(output, args...)
 
 Extract the frequency-domain `Eω` from the `output` (additional `args...` are passed to `getEω`) and
 extract the spectral phase, subtracting the linear phase ramp corresponding
 to a pulse in the middle of the time window defined by the frequency grid.
 """
-function getφ(output, args...)
+function spectral_phase(output, args...)
     ω, Eω = getEω(output, args...)
     grid = makegrid(output)
     t = grid.t
     τ = length(t) * (t[2] - t[1])/2 # middle of time window
-    getφ(ω, Eω, τ)
+    spectral_phase(ω, Eω, τ)
 end
 
 """
@@ -721,7 +721,7 @@ If `relative` is `true`, `width` is relative bandwidth instead of the wavelength
 `ndims` determines how many dimensions of the array to sum over. For a field array with size
 `(Nω, N1, N2, ...)`, the first dimension is always assumed to be frequency. `ndim=1` means
 each field to be analysed is 1-dimensional, so the window iterates over all of `(N1, N2, ...)`.
-`ndim=2` means each field to be analysed is 2-dimensional, `(Nω, N1)` in size, and will be 
+`ndim=2` means each field to be analysed is 2-dimensional, `(Nω, N1)` in size, and will be
 summed over its second dimension before finding the central frequency. The window iterates
 over all other dimensions, `(N2, ...)`.
 
@@ -765,7 +765,7 @@ end
     PeakWindow(width, λmin, λmax; relative=false, ndims=1)
 
 An [`AutoWindow`](@ref) which uses the peak of the spectral energy density as the central
-frequency. 
+frequency.
 """
 function PeakWindow(width, λmin, λmax; relative=false, ndims=1)
     ω0fun = (ω, Iω) ->  ω[argmax(Iω)]
@@ -776,7 +776,7 @@ end
     CentroidWindow(width, λmin, λmax; relative=false, ndims=1, power=1)
 
 An [`AutoWindow`](@ref) which uses the centroid (centre of mass or first moment) of the
-spectral energy density as the central frequency. Before calculating the centroid, the 
+spectral energy density as the central frequency. Before calculating the centroid, the
 SED is raised to the `power` given.
 """
 function CentroidWindow(width, λmin, λmax; relative=false, ndims=1, power=1)
@@ -1015,7 +1015,7 @@ function getEtxy(Etm, modes, xs::Tuple{AbstractVector, AbstractVector}, z; compo
             @views Modes.to_space!(Etxy[:, x1idx, x2idx, :], Etm[.., 1], (x1i, x2i), tospace; z)
         end
     end
-    Etxy    
+    Etxy
 end
 
 function polarisation_components(output)


### PR DESCRIPTION
Rename `getφ` to `spectral_phase` to avoid spelling issues with two different glyphs for φ which sometimes turn up.