### PR TITLE
Allow loss to be a scaling Real or frequency-dependent Function

### DIFF
--- a/src/Antiresonant.jl
+++ b/src/Antiresonant.jl
@@ -5,12 +5,12 @@ import Printf: @sprintf
 import Luna: Capillary
 import Luna.PhysData: c, wlfreq, ref_index_fun
 @reexport using Luna.Modes
-import Luna.Modes: AbstractMode, dimlimits, neff, field, Aeff, N, α, chkzkwarg
+import Luna.Modes: AbstractMode, dimlimits, neff, field, Aeff, N, α, chkzkwarg, wraptype
 
 struct ZeisbergerMode{mT<:Capillary.MarcatiliMode, LT} <: AbstractMode
     m::mT
     wallthickness::Float64
-    loss::LT # Val{true}(), Val{false}() or a number (scaling factor)
+    loss::LT # Val{true}(), Val{false}(), a Real (scaling factor), or a Function (ω -> scaling factor)
 end
 
 """
@@ -19,8 +19,9 @@ end
 Create a capillary-like mode with the effective index given by eq. (15) in [1].
 
 `wallthickness` (mandatory kwarg) sets the thickness of the anti-resonant struts and
-`loss` (optional, defaults to `true`) can be either a `Bool` (to switch on/off loss
-completely) or a `Real` (to up/down-scale the loss given by the model).
+`loss` (optional, defaults to `true`) can be a `Bool` (to switch on/off loss
+completely), a `Real` (to up/down-scale the loss given by the model), or a `Function`
+`f(ω)` returning a scaling factor as a function of angular frequency `ω`.
  Other kwargs are passed on to the constructor of a [`Capillary.MarcatiliMode`](@ref).
 
 [1] Zeisberger, M., Schmidt, M.A. Analytic model for the complex effective index of the
@@ -35,11 +36,6 @@ end
 function ZeisbergerMode(m::Capillary.MarcatiliMode; wallthickness, loss=true)
     ZeisbergerMode(m, wallthickness, wraptype(loss))
 end
-
-wraptype(loss::Bool) = Val(loss)
-wraptype(loss::Real) = loss
-wraptype(loss) = throw(
-    ArgumentError("loss has to be a Bool or Real, not $(typeof(loss))"))
 
 # Effective index is given by eq (15) in [1]
 neff(m::ZeisbergerMode, ω; z=0) = _neff(m.m, ω, m.wallthickness, m.loss; z=z)
@@ -68,7 +64,7 @@ function _neff(m::Capillary.MarcatiliMode, ω, wallthickness, loss; z=0)
             C = m.unm^4/8 + 2*m.unm^2*ϵ^2/(ϵ - 1)/tan(ϕ)^2
             D = m.unm^3*ϵ^2*(1+1/tan(ϕ)^2)/(ϵ - 1)
         end
-        return __neff(A, B, C, D, σ, nco, loss)
+        return __neff(A, B, C, D, σ, nco, loss, ω)
     else
         if m.kind == :EH
             s = 1
@@ -82,15 +78,17 @@ function _neff(m::Capillary.MarcatiliMode, ω, wallthickness, loss; z=0)
             + (m.unm^2/4*(2+m.m*s)*(ϵ+1)^2/(ϵ-1)
             - m.unm^4*(ϵ-1)/(8*m.m))*1/tan(ϕ)^2)
         D = m.unm^3/2 * (ϵ^2+1)/(ϵ-1) * (1 + 1/tan(ϕ)^2)
-        __neff(A, B, C, D, σ, nco, loss)
+        __neff(A, B, C, D, σ, nco, loss, ω)
     end
 end
 
 #= If ncl and nco are real, the type of neff depends on whether loss is included.
     Despatching on the type makes sure the type can be inferred by the compiler =#
-__neff(A, B, C, D, σ, nco, loss::Val{true}) = nco*(1 - A*σ^2 - B*σ^3 - C*σ^4 + 1im*D*σ^4)
-__neff(A, B, C, D, σ, nco, loss::Val{false}) = real(nco*(1 - A*σ^2 - B*σ^3 - C*σ^4))
-__neff(A, B, C, D, σ, nco, loss::Number) = nco*(1 - A*σ^2 - B*σ^3 - C*σ^4 + 1im*loss*D*σ^4)
+__neff(A, B, C, D, σ, nco, loss::Val{true}, ω) = nco*(1 - A*σ^2 - B*σ^3 - C*σ^4 + 1im*D*σ^4)
+__neff(A, B, C, D, σ, nco, loss::Val{false}, ω) = real(nco*(1 - A*σ^2 - B*σ^3 - C*σ^4))
+__neff(A, B, C, D, σ, nco, loss::Real, ω) = nco*(1 - A*σ^2 - B*σ^3 - C*σ^4 + 1im*loss*D*σ^4)
+__neff(A, B, C, D, σ, nco, loss::Function, ω) =
+    nco*(1 - A*σ^2 - B*σ^3 - C*σ^4 + 1im*loss(ω)*D*σ^4)
 
 
 struct VincettiMode{mT<:Capillary.MarcatiliMode, Tclad, LT} <: AbstractMode
@@ -100,7 +98,7 @@ struct VincettiMode{mT<:Capillary.MarcatiliMode, Tclad, LT} <: AbstractMode
     Ntubes::Int # number of tubes
     cladn::Tclad # cladding refractive index (constant, defaults to 1.45)
     Nterms::Int # number of terms (cladding modes) to include in the sum
-    loss::LT # Val{true}(), Val{false}() or a number (scaling factor)
+    loss::LT # Val{true}(), Val{false}(), a Real (scaling factor), or a Function (ω -> scaling factor)
 end
 
 """
@@ -120,7 +118,9 @@ to `Capillary.MarcatiliMode` but with the following additions/changes as keyword
 - `cladn` : refractive index of the resonators as a function of (ω; z). Defaults
             to the refractive index of silica (SiO2).
 - `Nterms` : number of resonator dielectric modes to include in the model. Defaults to 8.
-- `loss` : can be `true` or `false` to switch loss on/off, or a `Real` to scale the loss.
+- `loss` : can be `true` or `false` to switch loss on/off, a `Real` to scale the loss, or
+           a `Function` `f(ω)` returning a scaling factor as a function of angular
+           frequency `ω`.
 
 To specify the gap between resonators, calculate the core radius with [`getRco(r_ext, N, δ)`](@ref)
 or calculate the external radius of the resonators with [`getr_ext(Rco, N, δ)`](@ref).
@@ -157,7 +157,8 @@ neff(m::VincettiMode, ω; z=0) = neff_real(m, ω; z) + 1im*c/ω*α(m, ω; z)
 
 α(m::VincettiMode{mT, cT, Val{true}}, ω; z=0) where {mT, cT} = log(10)/10 * CL(m, ω; z)
 α(m::VincettiMode{mT, cT, Val{false}}, ω; z=0) where {mT, cT} = zero(ω)
-α(m::VincettiMode{mT, cT, <:Number}, ω; z=0) where {mT, cT} = m.loss * log(10)/10 * CL(m, ω; z)
+α(m::VincettiMode{mT, cT, <:Real}, ω; z=0) where {mT, cT} = m.loss * log(10)/10 * CL(m, ω; z)
+α(m::VincettiMode{mT, cT, <:Function}, ω; z=0) where {mT, cT} = m.loss(ω) * log(10)/10 * CL(m, ω; z)
 
 # All other mode properties are identical to a MarcatiliMode
 for fun in (:field, :N, :dimlimits)

--- a/src/Capillary.jl
+++ b/src/Capillary.jl
@@ -7,7 +7,7 @@ using Reexport
 @reexport using Luna.Modes
 import Luna: Maths, Grid
 import Luna.PhysData: c, ε_0, μ_0, ref_index_fun, roomtemp, densityspline, sellmeier_gas
-import Luna.Modes: AbstractMode, dimlimits, neff, field, Aeff, N, modeinfo
+import Luna.Modes: AbstractMode, dimlimits, neff, field, Aeff, N, modeinfo, wraptype
 import Luna.LinearOps: make_linop, conj_clamp, neff_grid, neff_β_grid
 import Luna.PhysData: wlfreq, roomtemp
 import Luna.Utils: subscript
@@ -36,18 +36,23 @@ struct MarcatiliMode{Ta, Tcore, Tclad, LT} <: AbstractMode
     coren::Tcore # callable, returns (possibly complex) core ref index as function of ω
     cladn::Tclad # callable, returns (possibly complex) cladding ref index as function of ω
     model::Symbol # if :full, includes complete influence of complex cladding ref index
-    loss::LT # Val{true}() or Val{false}() - whether to include the loss
+    loss::LT # Val{true}(), Val{false}(), a Real (scaling factor) or a Function ω -> scaling factor
     aeff_intg::Float64 # Pre-calculated integral fraction for effective area
 end
 
 function show(io::IO, m::MarcatiliMode)
     a = radius_string(m)
-    loss = "loss=" * (m.loss == Val(true) ? "true" : "false")
+    loss = "loss=" * lossstring(m.loss)
     model = "model="*string(m.model)
     angle = "ϕ=$(m.ϕ/π)π"
     out = "MarcatiliMode{"*join([mode_string(m), a, loss, model, angle], ", ")*"}"
     print(io, out)
 end
+
+lossstring(::Val{true}) = "true"
+lossstring(::Val{false}) = "false"
+lossstring(loss::Real) = string(loss)
+lossstring(::Function) = "function"
 
 mode_string(m::MarcatiliMode) = string(m.kind)*subscript(m.n)*subscript(m.m)
 radius_string(m::MarcatiliMode{<:Number, Tco, Tcl, LT}) where {Tco, Tcl, LT} = "a=$(m.a)"
@@ -55,7 +60,12 @@ radius_string(m::MarcatiliMode) = "a(z=0)=$(radius(m, 0))"
 
 modeinfo(m::MarcatiliMode) = Dict(:kind => m.kind, :n => m.n, :m => m.m,
                                   :radius => radius(m, 0), :ϕ => m.ϕ, :model => m.model,
-                                  :loss => m.loss == Val(true))
+                                  :loss => losslabel(m.loss))
+
+losslabel(::Val{true}) = true
+losslabel(::Val{false}) = false
+losslabel(loss::Real) = loss
+losslabel(::Function) = true
 
 """
     MarcatiliMode(a, n, m, kind, ϕ, coren, cladn; model=:full, loss=true)
@@ -75,7 +85,11 @@ Create a MarcatiliMode.
 - `model::Symbol=:full` : If `:full`, use the complete Marcatili model which takes into
                           account the dispersive influence of the cladding refractive index.
                           If `:reduced`, use the simplified model common in the literature
-- `loss::Bool=true` : Whether to include loss.
+- `loss::Union{Bool, Real, Function}=true` : Controls the propagation loss.
+  - `Bool`: enable (`true`) or disable (`false`) loss completely.
+  - `Real`: constant factor scaling the modal loss.
+  - `Function`: callable `f(ω)` returning a factor (as a function of angular frequency
+    `ω`) which scales the modal loss.
 
 """
 function MarcatiliMode(a, n, m, kind, ϕ, coren, cladn; model=:full, loss=true)
@@ -83,7 +97,7 @@ function MarcatiliMode(a, n, m, kind, ϕ, coren, cladn; model=:full, loss=true)
     aeff_intg = Aeff_Jintg(n, get_unm(n, m, kind), kind)
     MarcatiliMode(a, n, m, kind, get_unm(n, m, kind), ϕ,
                    chkzkwarg(coren), chkzkwarg(cladn),
-                   model, Val(loss), aeff_intg)
+                   model, wraptype(loss), aeff_intg)
 end
 
 """
@@ -185,6 +199,29 @@ function neff(m::MarcatiliMode{Ta, Tco, Tcl, Val{false}}, ω, εco, vn, a) where
     end
 end
 
+# m.loss is a Real (constant scaling factor) or Function (ω -> scaling factor):
+# compute the full complex neff, as for Val{true}, then scale its imaginary
+# (loss) part by the given factor
+lossfactor(loss::Real, ω) = loss
+lossfactor(loss::Function, ω) = loss(ω)
+
+function neff(m::MarcatiliMode{Ta, Tco, Tcl, LT}, ω, εco, vn, a
+              ) where {Ta, Tcl, Tco, LT<:Union{Real, Function}}
+    s = lossfactor(m.loss, ω)
+    if m.model == :full
+        k = ω/c
+        n = sqrt(complex(εco - (m.unm/(k*a))^2*(1 - im*vn/(k*a))^2))
+        nr, ni = real(n), s*imag(n)
+        return (nr < 1e-3) ? (1e-3 + im*clamp(ni, 0, Inf)) : (nr + im*ni)
+    elseif m.model == :reduced
+        nr = 1 + (εco - 1)/2 - c^2*m.unm^2/(2*ω^2*a^2)
+        ni = s*(c^3*m.unm^2)/(a^3*ω^3)*vn
+        return nr + im*ni
+    else
+        error("model must be :full or :reduced")
+    end
+end
+
 function neff_wg(m::MarcatiliMode{Ta, Tco, Tcl, Val{true}}, ω; z=0) where {Ta, Tcl, Tco}
     εcl = m.cladn(ω, z=z)^2
     vn = get_vn(εcl, m.kind)
@@ -213,7 +250,24 @@ function neff_wg(m::MarcatiliMode{Ta, Tco, Tcl, Val{false}}, ω; z=0) where {Ta,
     end
 end
 
-function neff(m::MarcatiliMode{Ta, Tco, Tcl, Val{true}}, εco, nwg) where {Ta, Tcl, Tco}
+# for a Real/Function loss, always compute the full complex waveguide term (as for
+# Val{true}); the scaling by the loss factor is applied afterwards in neff(m, εco, nwg, ω)
+function neff_wg(m::MarcatiliMode{Ta, Tco, Tcl, LT}, ω; z=0
+                  ) where {Ta, Tcl, Tco, LT<:Union{Real, Function}}
+    εcl = m.cladn(ω, z=z)^2
+    vn = get_vn(εcl, m.kind)
+    a = radius(m, z)
+    if m.model == :full
+        k = ω/c
+        return (m.unm/(k*a))^2*(1 - im*vn/(k*a))^2
+    elseif m.model == :reduced
+        return c^2*m.unm^2/(2*ω^2*a^2) + im*(c^3*m.unm^2)/(a^3*ω^3)*vn
+    else
+        error("model must be :full or :reduced")
+    end
+end
+
+function neff(m::MarcatiliMode{Ta, Tco, Tcl, Val{true}}, εco, nwg, ω) where {Ta, Tcl, Tco}
     if m.model == :full
         return sqrt(complex(εco - nwg))
     elseif m.model == :reduced
@@ -223,7 +277,7 @@ function neff(m::MarcatiliMode{Ta, Tco, Tcl, Val{true}}, εco, nwg) where {Ta, T
     end
 end
 
-function neff(m::MarcatiliMode{Ta, Tco, Tcl, Val{false}}, εco, nwg) where {Ta, Tcl, Tco}
+function neff(m::MarcatiliMode{Ta, Tco, Tcl, Val{false}}, εco, nwg, ω) where {Ta, Tcl, Tco}
     if m.model == :full
         return real(sqrt(complex(εco - nwg)))
     elseif m.model == :reduced
@@ -231,6 +285,19 @@ function neff(m::MarcatiliMode{Ta, Tco, Tcl, Val{false}}, εco, nwg) where {Ta, 
     else
         error("model must be :full or :reduced")
     end
+end
+
+function neff(m::MarcatiliMode{Ta, Tco, Tcl, LT}, εco, nwg, ω
+              ) where {Ta, Tcl, Tco, LT<:Union{Real, Function}}
+    s = lossfactor(m.loss, ω)
+    if m.model == :full
+        n = sqrt(complex(εco - nwg))
+    elseif m.model == :reduced
+        n = complex(1 + (εco - 1)/2 - nwg)
+    else
+        error("model must be :full or :reduced")
+    end
+    return real(n) + im*s*imag(n)
 end
 
 function get_vn(εcl, kind)
@@ -351,7 +418,7 @@ function neff_β_grid(grid,
         nwg[iω] = neff_wg(mode, grid.ω[iω]; z=0)
     end
     _neff = let nwg=nwg, ω=grid.ω, mode=mode
-        _neff(iω; z) = neff(mode, mode.coren(ω[iω], z=z)^2, nwg[iω])
+        _neff(iω; z) = neff(mode, mode.coren(ω[iω], z=z)^2, nwg[iω], ω[iω])
     end
     _β = let nwg=nwg, ω=grid.ω, _neff=_neff
         _β(iω; z) = ω[iω]/c*real(_neff(iω; z=z))
@@ -374,7 +441,7 @@ function neff_grid(grid, modes::FixedCoreCollection, λ0; ref_mode=1)
         end
     end
     _neff = let nwg=nwg, ω=grid.ω, modes=modes
-        _neff(iω, iim; z) = neff(modes[iim], modes[iim].coren(ω[iω], z=z)^2, nwg[iω, iim])
+        _neff(iω, iim; z) = neff(modes[iim], modes[iim].coren(ω[iω], z=z)^2, nwg[iω, iim], ω[iω])
     end
     _neff
 end

--- a/src/Modes.jl
+++ b/src/Modes.jl
@@ -9,7 +9,7 @@ import Memoize: @memoize
 import LinearAlgebra: mul!
 import DSP: unwrap
 
-export dimlimits, neff, β, α, losslength, transmission, dB_per_m, dispersion, zdw, field, Exy, Aeff, @delegated, @arbitrary, chkzkwarg
+export dimlimits, neff, β, α, losslength, transmission, dB_per_m, dispersion, zdw, field, Exy, Aeff, @delegated, @arbitrary, chkzkwarg, wraptype
 
 """
     AbstractMode
@@ -263,6 +263,20 @@ function chkzkwarg(func)
         end
     end
 end
+
+"""
+    wraptype(loss)
+
+Normalise a `loss` argument (as accepted by mode constructors) for use as a type
+parameter. `Bool` is wrapped as `Val{true}()`/`Val{false}()` so that dispatch on the loss
+type is compile-time; `Real` (constant scaling factor) and `Function` (frequency-dependent
+scaling factor, called as `loss(ω)`) are passed through unchanged.
+"""
+wraptype(loss::Bool) = Val(loss)
+wraptype(loss::Real) = loss
+wraptype(loss::Function) = loss
+wraptype(loss) = throw(
+    ArgumentError("loss has to be a Bool, Real, or Function, not $(typeof(loss))"))
 
 """
     overlap(m::AbstractMode, r, E; dim)

--- a/test/test_antiresonant.jl
+++ b/test/test_antiresonant.jl
@@ -24,6 +24,8 @@ import Luna.PhysData: wlfreq
     @test Modes.neff(arm, 2.5e15) == 0.9999193518567425
     arm = Antiresonant.ZeisbergerMode(a, :Air, 0, (ω; z) -> 1.45; wallthickness=w, loss=0.5)
     @test Modes.neff(arm, 2.5e15) ≈ 0.9999193518567425 + 0.5*1.87925966056515e-6im
+    arm = Antiresonant.ZeisbergerMode(a, :Air, 0, (ω; z) -> 1.45; wallthickness=w, loss=ω -> 0.5)
+    @test Modes.neff(arm, 2.5e15) ≈ 0.9999193518567425 + 0.5*1.87925966056515e-6im
     @test_throws ArgumentError Antiresonant.ZeisbergerMode(a, :Air, 0; wallthickness=w, loss=0.5im)
 end
 
@@ -55,6 +57,10 @@ end
     m0 = Antiresonant.VincettiMode(Rco; wallthickness=t, tube_radius=r_ext, Ntubes=N, cladn,
                                         loss=false)
     @test all(Modes.α.(m0, wlfreq.(λ)) .== 0)
+
+    mfun = Antiresonant.VincettiMode(Rco; wallthickness=t, tube_radius=r_ext, Ntubes=N, cladn,
+                                        loss=ω -> scale)
+    @test Modes.α.(mfun, wlfreq.(λ)) ≈ Modes.α.(msc, wlfreq.(λ))
 
     @test Modes.neff(m, wlfreq(1030e-9)) ≈ 0.9998598623672965 + 3.4579455755137454e-8im
 

--- a/test/test_capillary.jl
+++ b/test/test_capillary.jl
@@ -16,6 +16,44 @@ import Luna.PhysData: wlfreq
     @test Capillary.dB_per_m(m, ω) ≈ 8*Capillary.dB_per_m(Capillary.MarcatiliMode(2a, :HeB, 1.0, model=:reduced), ω)
 end
 
+@testset "loss scaling/function" begin
+    λ = 800e-9
+    ω = wlfreq(λ)
+    a = 125e-6
+    for model in (:full, :reduced)
+        mtrue = Capillary.MarcatiliMode(a, :HeB, 1.0, model=model, loss=true)
+        mfalse = Capillary.MarcatiliMode(a, :HeB, 1.0, model=model, loss=false)
+        mhalf = Capillary.MarcatiliMode(a, :HeB, 1.0, model=model, loss=0.5)
+        mfun = Capillary.MarcatiliMode(a, :HeB, 1.0, model=model, loss=ω -> 0.5)
+
+        ntrue = Modes.neff(mtrue, ω)
+        nfalse = Modes.neff(mfalse, ω)
+        nhalf = Modes.neff(mhalf, ω)
+        nfun = Modes.neff(mfun, ω)
+
+        @test imag(nfalse) == 0
+        @test real(nhalf) ≈ real(ntrue)
+        @test imag(nhalf) ≈ 0.5*imag(ntrue)
+        @test nfun ≈ nhalf
+        @test isreal(nfalse)
+    end
+
+    # loss=1 should be identical to loss=true
+    mtrue = Capillary.MarcatiliMode(a, :HeB, 1.0, model=:full, loss=true)
+    mone = Capillary.MarcatiliMode(a, :HeB, 1.0, model=:full, loss=1.0)
+    @test Modes.neff(mtrue, ω) ≈ Modes.neff(mone, ω)
+
+    # a fixed-radius mode also goes through the cached neff_grid/neff_β_grid path
+    grid = Grid.RealGrid(15e-2, λ, (160e-9, 3000e-9), 1e-12)
+    mhalf = Capillary.MarcatiliMode(a, :HeB, 1.0, model=:full, loss=0.5)
+    mfun = Capillary.MarcatiliMode(a, :HeB, 1.0, model=:full, loss=ω -> 0.5)
+    _neffh, _βh = Capillary.neff_β_grid(grid, mhalf, λ)
+    _nefff, _βf = Capillary.neff_β_grid(grid, mfun, λ)
+    iω = findfirst(grid.sidx)
+    @test _neffh(iω; z=0) ≈ _nefff(iω; z=0)
+    @test _neffh(iω; z=0) ≈ Modes.neff(mhalf, grid.ω[iω])
+end
+
 @testset "normalisation" begin
     # Copied definitions from Modes.jl to force manual calculation of Aeff and N
     # these also return the integration error to make comparisons easier


### PR DESCRIPTION
MarcatiliMode's loss kwarg previously only accepted Bool. Extend it, and the ZeisbergerMode/VincettiMode loss kwargs that already accepted Real, to also accept a Function ω -> factor for frequency-dependent loss scaling. Share the Bool/Real/Function normalisation (wraptype) between Capillary and Antiresonant instead of duplicating it.