### PR TITLE
Propagate the modified shot-noise field under the unitary linear operator

### DIFF
--- a/docs/src/model/noise.md
+++ b/docs/src/model/noise.md
@@ -31,17 +31,18 @@ the stimulated evolution of the injected noise.
 
 While simple, this approach has several well-known limitations:
 
-1. **Artificial FWM phase-matching**: The noise field, superimposed on the input pulse,
-   acquires a coherent phase increment from dispersion during propagation. This means the
-   noise can satisfy phase-matching conditions for FWM, which is unphysical --- real vacuum
-   fluctuations are incoherent and cannot maintain phase-matching over extended distances.
+1. **Elevated noise floor**: The noise creates a persistent increase of the spectral
+   intensity at all frequencies that does not decay. In particular, the spectrum at ``z = 0``
+   already contains a noise floor everywhere, so there is no clean baseline against which to
+   measure spontaneously generated light.
 
-2. **Elevated noise floor**: The noise creates a persistent increase of the spectral
-   intensity at all frequencies that does not decay.
-
-3. **No Stokes/anti-Stokes asymmetry**: Spontaneous Raman generation exhibits a fundamental
+2. **No Stokes/anti-Stokes asymmetry**: Spontaneous Raman generation exhibits a fundamental
    spectral asymmetry (Stokes is favoured by an extra quantum of vacuum fluctuation). The
    traditional model does not capture this.
+
+3. **No spontaneous generation in absorptive media**: the input noise is attenuated along with
+   the field, whereas a real vacuum field is replenished by the same process that causes the
+   loss.
 
 ## Modified shot noise (`:modified`)
 
@@ -54,13 +55,17 @@ field in the **nonlinear operator** rather than in the input field:
 
 The key structural features are:
 
-- **Dispersion acts only on the physical field**: ``\hat{\mathcal{D}}\,A``, not
-  ``\hat{\mathcal{D}}(A + A_{\mathrm{noise}})``. This prevents the noise from acquiring
-  coherent phase increments that would cause artificial FWM phase-matching.
+- **The noise is not part of the propagating field**: the linear operator
+  ``\hat{\mathcal{D}}`` acts on ``A`` alone, so the spectrum that is saved and plotted never
+  contains a noise floor, and the noise is never amplified or attenuated by the propagation
+  itself. It is a source, not a seed.
 
-- **The noise field is constant**: ``A_{\mathrm{noise}}(\omega)`` is generated once before
-  propagation with one-photon-per-mode spectral density and random phase, and held fixed
-  throughout. It does not evolve, grow, or accumulate.
+- **The noise field is drawn once**: ``A_{\mathrm{noise}}`` is generated before propagation
+  with one-photon-per-mode spectral density and random spectral phase, and is never
+  re-randomised. This is what keeps the result step-size independent (a noise field redrawn
+  along ``z`` would make the answer depend on the step count).
+
+- **It is advanced by the unitary part of the linear operator** --- see the next section.
 
 - **All nonlinear processes are correctly seeded**: Both Kerr (FWM/MI) and Raman
   (spontaneous Stokes/anti-Stokes) processes are seeded through the same mechanism ---
@@ -73,6 +78,40 @@ The key structural features are:
 This approach is a **general-purpose noise model** applicable to all ``\chi^{(3)}``
 propagation problems, including MI-based supercontinuum generation, Raman comb formation,
 soliton dynamics with self-frequency shift, and combined Kerr--Raman broadening.
+
+## How the noise field evolves
+
+``A_{\mathrm{noise}}`` is drawn once and then advanced under the **unitary** part of the
+linear operator only:
+
+```math
+A_{\mathrm{noise}}(\omega, z) = A_{\mathrm{noise}}(\omega, 0)\,
+    \exp\!\left[i\!\int_0^z \mathrm{Im}\,\hat{\mathcal{D}}(\omega, z')\,
+    \mathrm{d}z'\right]
+```
+
+| part of the linear operator | acts on the noise? | why |
+|---|---|---|
+| dispersion | **yes** | It is unitary, and it is the phase evolution of the medium's own vacuum modes. |
+| loss | **no** | Fluctuation--dissipation: loss replenishes the vacuum rather than removing it, so the local noise level stays at one photon per mode. This is what allows the model to seed spontaneous generation in an absorbing medium, saturating at ``P_{\mathrm{noise}}``. |
+| gain | **no** | The source term already injects fresh vacuum at every ``z``, which the homogeneous propagator then amplifies over the remaining length --- that integral *is* the amplified spontaneous emission. Amplifying the noise as well would double-count it. |
+
+Note that *constant* here means **not re-randomised**, which is what the step-size-independence
+argument of Ref. [1] actually requires --- not un-propagated. Holding the noise field literally
+fixed is exact only in the dispersion-free gain model in which Ref. [1] derives its identity
+``A_s = A_s' + A_{\mathrm{noise}}``. In a dispersive medium the traditional model's input noise
+*does* disperse, so a static ``A_{\mathrm{noise}}`` breaks that identity in proportion to how
+much dispersion has acted. The consequence is a magnitude error in **phase-sensitive**
+processes (Kerr MI and FWM, where the ``\pm\Omega`` sideband pair must hold a fixed phase
+relation to the pump, and that relation is exactly what dispersion controls) of up to a factor
+of a few per frequency, and much more in propagation with no net gain, where an injected source
+has nothing to dilute it. Applying the *full* linearised operator instead is worse than doing
+nothing, because the source term already supplies the nonlinear part.
+
+Phase-insensitive processes are unaffected either way: Raman gain does not depend on the phase
+of the Stokes wave relative to the pump, so denying the noise its phase evolution rotates
+phases that never mattered. Pure-Raman results are identical to five significant figures with
+or without this term.
 
 ## Usage
 
@@ -106,6 +145,11 @@ Setting `shotnoise=false` disables noise entirely. This prevents generation of t
 field when using the modified model, and prevents adding shot noise to the input spectrum
 when using the traditional model.
 
+The noise realisation used by the modified model is written to the output as `"noise_field"`
+(the ``z = 0`` draw). Passing `save_noise=true` additionally stores the accumulated phase at
+every output plane, which is what [`Processing.withnoise`](@ref Luna.Processing.withnoise)
+needs to reconstruct ``A_{\mathrm{noise}}(z)`` from a saved file.
+
 ## Ionization and plasma
 
 In the modified shot-noise model, the combined field ``A + A_{\mathrm{noise}}`` is passed to
@@ -123,26 +167,39 @@ meaningfully affected by the noise injection.
 Because the noise is not added to the propagating field, spontaneously generated spectral
 components start from exactly zero power at ``z = 0``. At very small ``z``, the power
 ``|A_{s'}|^2 \propto z^2`` (quadratic growth), which is the expected linearised result.
-To recover the correct physical power including the vacuum fluctuation contribution, one
-can temporarily add the noise before computing the power:
+To recover the correct physical power including the vacuum fluctuation contribution, add the
+noise back before computing the power:
 
 ```math
-P_{s'}(z) = |A_{s'}(z) + A_{\mathrm{noise}}|^2 - P_{\mathrm{noise}}
+P_{s'}(z) = |A_{s'}(z) + A_{\mathrm{noise}}(z)|^2 - P_{\mathrm{noise}}
+```
+
+[`Processing.withnoise`](@ref Luna.Processing.withnoise) performs the restoration:
+
+```julia
+out = prop_capillary(a, L, gas, P; ..., shotnoise=:modified, save_noise=true)
+grid = Processing.makegrid(out)
+E = Processing.energy(grid, Processing.withnoise(out); bandpass=(1100e-9, 1500e-9))
 ```
 
 This correction is only necessary when the generated power is comparable to or below the
 noise floor. At higher powers (the stimulated/saturated regime), ``|A_{s'}|^2`` directly
-gives the correct result.
+gives the correct result. Note also that the ``-P_{\mathrm{noise}}`` term is there because
+Ref. [1] wants the *generated* power; if the quantity being compared against already includes
+the seed --- as it does when comparing with a `shotnoise=:input` run --- subtracting it again
+double-counts.
 
 ## Comparison
 
 | Feature | Traditional (`:input`) | Modified (`:modified`) |
 |---------|----------------------|----------------------|
-| Artificial FWM phase-matching | Yes | No |
 | Elevated noise floor | Yes | No |
+| Clean spectrum at ``z = 0`` | No | Yes |
 | Stokes/anti-Stokes asymmetry | Not captured | Effectively captured |
+| Spontaneous generation in absorbing media | Not captured | Captured |
 | Captures all cascaded processes | Only through stimulated evolution | Automatically |
 | Step-size sensitivity | No | No |
+| Noise background included in the saved spectrum | Yes | No --- see [`Processing.withnoise`](@ref Luna.Processing.withnoise) |
 
 ## References
 

--- a/src/Fields.jl
+++ b/src/Fields.jl
@@ -332,14 +332,16 @@ real-valued field (rFFT normalisation). When `nmodes > 1`, returns an `(nω, nmo
 with independent noise per mode for multimode propagation.
 
 Unlike [`ShotNoise`](@ref), which is added to the input field at `z = 0`, this noise field
-is intended to be injected into the **nonlinear operator** at every propagation step via the
-`noise_field` keyword argument. The dispersion operator does not act on this noise,
-preventing artificial FWM phase-matching — the key advantage over the traditional shot-noise
-approach.
+is intended to be injected into the **nonlinear operator** at every propagation step. It is
+never added to the propagating field, which is what keeps the saved spectrum free of a noise
+floor.
 
-The noise field is generated once before propagation and held constant throughout. Different
-random seeds (via `rng`) produce different noise realisations for ensemble/shot-to-shot
-statistics.
+The field returned here is the `z = 0` draw. Bundle it with
+[`LinearOps.unitary_phase`](@ref Luna.LinearOps.unitary_phase) into a
+[`NonlinearRHS.ModifiedNoise`](@ref Luna.NonlinearRHS.ModifiedNoise), which advances it along
+`z` under the unitary (dispersion-only) part of the linear operator. It is drawn once and
+never re-randomised, so results remain step-size independent. Different random seeds (via
+`rng`) produce different noise realisations for ensemble/shot-to-shot statistics.
 
 # References
 - Chen & Wise, "A simple accurate way to model noise-seeded ultrafast nonlinear processes",

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -918,13 +918,34 @@ which is what [`Processing.withnoise`](@ref Luna.Processing.withnoise) needs to 
 noise background from a saved file. That array is half the size of `Eω`, so it is off by
 default.
 
+If `output` already contains a noise field, this is a cached `HDF5Output` being resumed, and
+the recorded realisation is adopted for the rest of the propagation instead (the `rng`
+argument is ignored, with a message saying so). That matters more here than it would for
+`shotnoise=:input`, where the noise enters only the initial condition and is therefore
+carried by the cached field: the modified model uses the noise at *every* step, so continuing
+with a fresh draw would splice two different realisations together and leave the already-saved
+planes inconsistent with the recorded one.
+
 Does nothing unless the modified shot-noise model is in use.
 """
 function savenoise(output, transform, grid, saveN, save_noise)
     noise = hasfield(typeof(transform), :noise) ? transform.noise : nothing
     isnothing(noise) && return
-    output("noise_field", noise.Eω0)
+    if haskey(output, "noise_field")
+        saved = output["noise_field"]
+        size(saved) == size(noise.Eω0) || error(
+            "the noise field saved in this output has size $(size(saved)) but this "*
+            "simulation needs $(size(noise.Eω0)) -- the output belongs to a different "*
+            "simulation")
+        noise.Eω0 .= saved
+        noise.lastz[] = NaN
+        @info("Adopting the noise realisation already recorded in the output; the `rng` "*
+              "argument is ignored when resuming a cached run.")
+    else
+        output("noise_field", noise.Eω0)
+    end
     save_noise || return
+    haskey(output, "noise_phase") && return # already recorded, and a function of the draw
     Φ = zeros(Float64, (size(noise.Eω0)..., saveN))
     d = ndims(Φ)
     for (i, z) in enumerate(range(0, stop=grid.zmax, length=saveN))

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -292,9 +292,11 @@ In this case, all keyword arguments except for `λ0` are ignored.
     - `true` (default) -- same as `:modified`.
     - `false` -- disable all noise.
     - `:modified` -- use the modified shot-noise model of Chen & Wise
-      (arXiv:2410.20567), where a constant noise field enters the nonlinear operator
-      at every step but is excluded from dispersion. This prevents artificial FWM
-      phase-matching and elevated noise floor artefacts.
+      (arXiv:2410.20567), where a noise field enters the nonlinear operator at every step
+      but is never added to the propagating field. The noise field is drawn once and then
+      advanced under the *unitary* part of the linear operator only -- dispersion, but
+      neither loss nor gain. This gives a spectrum with no elevated noise floor, Raman
+      Stokes/anti-Stokes asymmetry, and spontaneous generation in absorbing media.
     - `:input` -- use traditional one-photon-per-mode shot noise added to the input
       field at `z = 0`.
     See the [Noise model](@ref) documentation for details.
@@ -343,6 +345,11 @@ If `raman` is `true`, then the following options apply:
 # Output options
 - `stats_kwargs::Dict{Symbol, Any}`: a dictionary of keyword arguments to `Stats.default`
 - `saveN::Integer`: Number of points along z at which to save the field.
+- `save_noise::Bool`: If `true`, additionally save the accumulated phase of the modified
+    shot-noise field at every output plane, so that the noise background can be restored
+    from the saved file with [`Processing.withnoise`](@ref Luna.Processing.withnoise). The
+    `z = 0` noise draw is always saved as `"noise_field"`. Defaults to `false`, since the
+    extra array is half the size of the saved field.
 - `filepath`: If `nothing` (default), create a `MemoryOutput` to store the simulation results
     only in the working memory. If not `nothing`, should be a file path as a `String`,
     and the results are saved in a file at this location. If `scan` is passed, `filepath`
@@ -354,10 +361,16 @@ If `raman` is `true`, then the following options apply:
 - `filename`: Can be used to to overwrite the scan name when running a parameter scan.
     The running `scanidx` will be appended to this filename. Ignored if no `scan` is given.
 - `status_period::Number`: Interval (in seconds) between printed status updates.
+
+# Integrator options
+- `rtol::Number`: Relative tolerance for the adaptive RK45 integrator. Defaults to `1e-6`.
+    Tighten this (e.g. `1e-10`) for work which is sensitive to accumulated integration
+    error, such as soliton recurrence or noise-seeded dynamics.
+- `atol::Number`: Absolute tolerance for the integrator. Defaults to `1e-10`.
 """
-function prop_capillary(args...; status_period=5, kwargs...)
+function prop_capillary(args...; status_period=5, rtol=1e-6, atol=1e-10, kwargs...)
     Eω, grid, linop, transform, FT, output = prop_capillary_args(args...; kwargs...)
-    Luna.run(Eω, grid, linop, transform, FT, output; status_period)
+    Luna.run(Eω, grid, linop, transform, FT, output; status_period, rtol, atol)
     output
 end
 
@@ -384,7 +397,7 @@ function prop_capillary_args(radius, flength, gas, pressure;
                         stats_kwargs=Dict{Symbol, Any}(),
                         PPT_options=Dict{Symbol, Any}(), preionfrac=0.0,
                         rotation=true, vibration=true, temperature=roomtemp,
-                        saveN=201, filepath=nothing,
+                        saveN=201, save_noise=false, filepath=nothing,
                         scan=nothing, scanidx=nothing, filename=nothing)
 
     # do we have energy in the orthogonal polarisation states, or just the fundamental?
@@ -416,11 +429,12 @@ function prop_capillary_args(radius, flength, gas, pressure;
                                      noise_field)
     stats = Stats.default(grid, Eω, mode_s, linop, transform; gas=gas, stats_kwargs...)
     output = makeoutput(grid, saveN, stats, filepath, scan, scanidx, filename)
+    savenoise(output, transform, grid, saveN, save_noise)
 
     saveargs(output; radius, flength, gas, pressure, λlims, trange, envelope, thg, δt,
         λ0, τfwhm, τw, ϕ, power, energy, pulseshape, polarisation, propagator, pulses,
         shotnoise, modes, model, loss, raman, kerr, plasma, PPT_options,
-        temperature, saveN, filepath, filename)
+        temperature, saveN, save_noise, filepath, filename)
 
     return Eω, grid, linop, transform, FT, output
 end
@@ -824,6 +838,20 @@ function makenoise(grid, mode_s, inputs, shotnoise::Symbol, rng)
     end
 end
 
+"""
+    makemodifiednoise(noise_field, linop, grid)
+
+Bundle the `z = 0` noise draw with the propagator which advances it, i.e. the accumulated
+**unitary** phase of `linop` (dispersion, but neither loss nor gain). Returns `nothing` if
+`noise_field` is `nothing`. See [`NonlinearRHS.ModifiedNoise`](@ref Luna.NonlinearRHS.ModifiedNoise).
+"""
+makemodifiednoise(noise_field::Nothing, linop, grid) = nothing
+
+function makemodifiednoise(noise_field, linop, grid)
+    phase = LinearOps.unitary_phase(linop, grid, size(noise_field))
+    NonlinearRHS.ModifiedNoise(noise_field, phase, grid)
+end
+
 function _add_input_shotnoise(inputs, mode::Modes.AbstractMode, rng)
     (inputs..., (mode=1, fields=(Fields.ShotNoise(rng),)))
 end
@@ -837,8 +865,9 @@ function setup(grid, mode::Modes.AbstractMode, density, responses, inputs, pol, 
     @info("Using mode-averaged propagation.")
     linop, βfun!, _, _ = LinearOps.make_const_linop(grid, mode, grid.referenceλ)
 
+    noise = makemodifiednoise(noise_field, linop, grid)
     Eω, transform, FT = Luna.setup(grid, density, responses, inputs,
-                                   βfun!, z -> Modes.Aeff(mode, z=z); noise_field)
+                                   βfun!, z -> Modes.Aeff(mode, z=z); noise)
     linop, Eω, transform, FT
 end
 
@@ -847,8 +876,9 @@ function setup(grid, mode::Modes.AbstractMode, density, responses, inputs, pol, 
     @info("Using mode-averaged propagation.")
     linop, βfun! = LinearOps.make_linop(grid, mode, grid.referenceλ)
 
+    noise = makemodifiednoise(noise_field, linop, grid)
     Eω, transform, FT = Luna.setup(grid, density, responses, inputs,
-                                   βfun!, z -> Modes.Aeff(mode, z=z); noise_field)
+                                   βfun!, z -> Modes.Aeff(mode, z=z); noise)
     linop, Eω, transform, FT
 end
 
@@ -861,8 +891,9 @@ function setup(grid, modes, density, responses, inputs, pol, rtol, c::Val{true};
     nf = needfull(modes)
     @info(nf ? "Using full 2-D modal integral." : "Using radial modal integral.")
     linop = LinearOps.make_const_linop(grid, modes, grid.referenceλ)
+    noise = makemodifiednoise(noise_field, linop, grid)
     Eω, transform, FT = Luna.setup(grid, density, responses, inputs, modes,
-                                   pol ? :xy : :y; full=nf, rtol, noise_field)
+                                   pol ? :xy : :y; full=nf, rtol, noise)
     linop, Eω, transform, FT
 end
 
@@ -871,9 +902,36 @@ function setup(grid, modes, density, responses, inputs, pol, rtol, c::Val{false}
     nf = needfull(modes)
     @info(nf ? "Using full 2-D modal integral." : "Using radial modal integral.")
     linop = LinearOps.make_linop(grid, modes, grid.referenceλ)
+    noise = makemodifiednoise(noise_field, linop, grid)
     Eω, transform, FT = Luna.setup(grid, density, responses, inputs, modes,
-                                   pol ? :xy : :y; full=nf, rtol, noise_field)
+                                   pol ? :xy : :y; full=nf, rtol, noise)
     linop, Eω, transform, FT
+end
+
+"""
+    savenoise(output, transform, grid, saveN, save_noise)
+
+Record the modified shot-noise realisation in `output`. The `z = 0` draw is always written as
+`"noise_field"`; it is small and identifies the realisation. When `save_noise` is `true` the
+accumulated unitary phase at each of the `saveN` output planes is written as `"noise_phase"`,
+which is what [`Processing.withnoise`](@ref Luna.Processing.withnoise) needs to restore the
+noise background from a saved file. That array is half the size of `Eω`, so it is off by
+default.
+
+Does nothing unless the modified shot-noise model is in use.
+"""
+function savenoise(output, transform, grid, saveN, save_noise)
+    noise = hasfield(typeof(transform), :noise) ? transform.noise : nothing
+    isnothing(noise) && return
+    output("noise_field", noise.Eω0)
+    save_noise || return
+    Φ = zeros(Float64, (size(noise.Eω0)..., saveN))
+    d = ndims(Φ)
+    for (i, z) in enumerate(range(0, stop=grid.zmax, length=saveN))
+        noise.phase(selectdim(Φ, d, i), z)
+    end
+    output("noise_phase", Φ)
+    return
 end
 
 function makeoutput(grid, saveN, stats, filepath::Nothing, scan::Nothing, scanidx, filename)
@@ -935,9 +993,11 @@ Note that the current GNLSE model is single mode only.
     - `true` (default) -- same as `:modified`.
     - `false` -- disable all noise.
     - `:modified` -- use the modified shot-noise model of Chen & Wise
-      (arXiv:2410.20567), where a constant noise field enters the nonlinear operator
-      at every step but is excluded from dispersion. This prevents artificial FWM
-      phase-matching and elevated noise floor artefacts.
+      (arXiv:2410.20567), where a noise field enters the nonlinear operator at every step
+      but is never added to the propagating field. The noise field is drawn once and then
+      advanced under the *unitary* part of the linear operator only -- dispersion, but
+      neither loss nor gain. This gives a spectrum with no elevated noise floor, Raman
+      Stokes/anti-Stokes asymmetry, and spontaneous generation in absorbing media.
     - `:input` -- use traditional one-photon-per-mode shot noise added to the input
       field at `z = 0`.
     See the [Noise model](@ref) documentation for details.
@@ -959,6 +1019,11 @@ Note that the current GNLSE model is single mode only.
 
 # Output options
 - `saveN::Integer`: Number of points along z at which to save the field.
+- `save_noise::Bool`: If `true`, additionally save the accumulated phase of the modified
+    shot-noise field at every output plane, so that the noise background can be restored
+    from the saved file with [`Processing.withnoise`](@ref Luna.Processing.withnoise). The
+    `z = 0` noise draw is always saved as `"noise_field"`. Defaults to `false`, since the
+    extra array is half the size of the saved field.
 - `filepath`: If `nothing` (default), create a `MemoryOutput` to store the simulation results
     only in the working memory. If not `nothing`, should be a file path as a `String`,
     and the results are saved in a file at this location. If `scan` is passed, `filepath`
@@ -970,10 +1035,16 @@ Note that the current GNLSE model is single mode only.
 - `filename`: Can be used to to overwrite the scan name when running a parameter scan.
     The running `scanidx` will be appended to this filename. Ignored if no `scan` is given.
 - `status_period::Number`: Interval (in seconds) between printed status updates.
+
+# Integrator options
+- `rtol::Number`: Relative tolerance for the adaptive RK45 integrator. Defaults to `1e-6`.
+    Tighten this (e.g. `1e-10`) for work which is sensitive to accumulated integration
+    error, such as soliton recurrence or noise-seeded dynamics.
+- `atol::Number`: Absolute tolerance for the integrator. Defaults to `1e-10`.
 """
-function prop_gnlse(args...; status_period=5, kwargs...)
+function prop_gnlse(args...; status_period=5, rtol=1e-6, atol=1e-10, kwargs...)
     Eω, grid, linop, transform, FT, output = prop_gnlse_args(args...; kwargs...)
-    Luna.run(Eω, grid, linop, transform, FT, output; status_period)
+    Luna.run(Eω, grid, linop, transform, FT, output; status_period, rtol, atol)
     output
 end
 
@@ -995,7 +1066,7 @@ function prop_gnlse_args(γ, flength, βs; λ0, λlims, trange,
                         rng=GLOBAL_RNG,
                         loss=0.0, raman=true, fr=0.18,
                         ramanmodel=:sdo, τ1=12.2e-15, τ2=32e-15,
-                        saveN=201, filepath=nothing,
+                        saveN=201, save_noise=false, filepath=nothing,
                         scan=nothing, scanidx=nothing, filename=nothing)
     envelope = true
     thg = false
@@ -1036,15 +1107,17 @@ function prop_gnlse_args(γ, flength, βs; λ0, λlims, trange,
     inputs, noise_field = makenoise(grid, mode_s, inputs, shotnoise, rng)
 
     norm! = NonlinearRHS.norm_mode_average_gnlse(grid, aeff; shock)
+    noise = makemodifiednoise(noise_field, linop, grid)
     Eω, transform, FT = Luna.setup(grid, density, resp, inputs, βfun!, aeff;
-                                   norm!, noise_field)
+                                   norm!, noise)
     stats = Stats.default(grid, Eω, mode_s, linop, transform)
     output = makeoutput(grid, saveN, stats, filepath, scan, scanidx, filename)
+    savenoise(output, transform, grid, saveN, save_noise)
 
     saveargs(output; γ, flength, βs, λlims, trange, envelope, thg, δt,
         λ0, τfwhm, τw, ϕ, power, energy, pulseshape, polarisation, propagator, pulses,
         shotnoise, shock, loss, raman, ramanmodel, fr, τ1, τ2,
-        saveN, filepath, filename)
+        saveN, save_noise, filepath, filename)
 
     return Eω, grid, linop, transform, FT, output
 end

--- a/src/LinearOps.jl
+++ b/src/LinearOps.jl
@@ -490,4 +490,133 @@ function make_linop(grid::Grid.EnvGrid, modes, λ0; ref_mode=1, thg=false)
 end
 
 
+
+#=================================================#
+#=========  UNITARY PHASE OF THE LINOP  ==========#
+#=================================================#
+
+"""
+    AbstractUnitaryPhase
+
+Callable which fills an array with the accumulated **unitary** phase of a linear operator,
+`Φ(ω, z) = ∫₀ᶻ imag(linop(ω, z')) dz'`, i.e. the phase the linear operator would impart in
+the absence of loss or gain. Subtypes implement `(p::AbstractUnitaryPhase)(out, z)`, which
+**mutates** `out` and returns it.
+
+This is the propagator required by the modified shot-noise model: the noise field must feel
+dispersion (unitary, and the phase evolution of the medium's own vacuum modes) but neither
+loss nor gain. See [`unitary_phase`](@ref) and
+[`NonlinearRHS.ModifiedNoise`](@ref Luna.NonlinearRHS.ModifiedNoise).
+"""
+abstract type AbstractUnitaryPhase end
+
+"""
+    ConstUnitaryPhase(dφ)
+
+[`AbstractUnitaryPhase`](@ref) for a `z`-invariant linear operator, for which
+`Φ(ω, z) = imag(linop)·z` exactly.
+"""
+struct ConstUnitaryPhase{aT<:AbstractArray} <: AbstractUnitaryPhase
+    dφ::aT # imag(linop), i.e. dΦ/dz, constant in z
+end
+
+(p::ConstUnitaryPhase)(out, z) = (@. out = p.dφ * z; out)
+
+"""
+    TabulatedUnitaryPhase(z, Φ, dΦ)
+
+[`AbstractUnitaryPhase`](@ref) for a `z`-dependent linear operator. `Φ` and `dΦ` hold the
+accumulated phase and its derivative `imag(linop)` on the uniform node grid `z`, stacked
+along the last dimension. Between nodes the phase is interpolated with a cubic Hermite, which
+uses both the tabulated value and the tabulated derivative and so matches the accuracy of the
+node integration. Outside `[z[1], z[end]]` it extrapolates linearly, which is needed because
+the integrator overshoots `grid.zmax` on its final step.
+"""
+struct TabulatedUnitaryPhase{aT<:AbstractArray} <: AbstractUnitaryPhase
+    z::LinRange{Float64, Int}
+    Φ::aT
+    dΦ::aT
+end
+
+function (p::TabulatedUnitaryPhase)(out, z)
+    zs = p.z
+    nz = length(zs)
+    d = ndims(p.Φ)
+    if z >= zs[end] # linear extrapolation past the end of the table
+        Φk = selectdim(p.Φ, d, nz)
+        dk = selectdim(p.dΦ, d, nz)
+        δ = z - zs[end]
+        @. out = Φk + dk*δ
+        return out
+    elseif z <= zs[1]
+        Φk = selectdim(p.Φ, d, 1)
+        dk = selectdim(p.dΦ, d, 1)
+        δ = z - zs[1]
+        @. out = Φk + dk*δ
+        return out
+    end
+    δz = step(zs)
+    k = min(floor(Int, (z - zs[1])/δz) + 1, nz-1)
+    s = (z - zs[k])/δz
+    # cubic Hermite basis
+    s2 = s*s
+    s3 = s2*s
+    h00 = 2s3 - 3s2 + 1
+    h10 = δz*(s3 - 2s2 + s)
+    h01 = -2s3 + 3s2
+    h11 = δz*(s3 - s2)
+    Φk = selectdim(p.Φ, d, k)
+    Φk1 = selectdim(p.Φ, d, k+1)
+    dk = selectdim(p.dΦ, d, k)
+    dk1 = selectdim(p.dΦ, d, k+1)
+    @. out = h00*Φk + h10*dk + h01*Φk1 + h11*dk1
+    out
+end
+
+"""
+    unitary_phase(linop, grid, sz=size(linop); nz=nothing)
+
+Create an [`AbstractUnitaryPhase`](@ref) for the linear operator `linop`, which may be either
+a constant array or a mutating function `linop!(out, z)`. `sz` is the size of the array
+`linop!` fills (equal to `size(linop)` in the constant case, and to the size of the noise
+field in general).
+
+For a `z`-dependent `linop!`, the accumulated phase is tabulated on `nz` uniform nodes over
+`[0, grid.zmax]`, each interval integrated by Simpson's rule (so `linop!` is evaluated
+`2nz-1` times in total, once per node and once per midpoint). `nz` defaults to a value chosen
+from a ~64 MB budget for the two tables, clamped to `[33, 401]`.
+"""
+unitary_phase(linop::AbstractArray, grid, sz=size(linop); nz=nothing) =
+    ConstUnitaryPhase(imag.(linop))
+
+function unitary_phase(linop!, grid, sz; nz=nothing)
+    nz = isnothing(nz) ? _default_phase_nz(prod(sz)) : nz
+    zs = LinRange(0.0, float(grid.zmax), nz)
+    δz = step(zs)
+    Φ = zeros(Float64, (sz..., nz))
+    dΦ = zeros(Float64, (sz..., nz))
+    d = ndims(Φ)
+    lo = Array{ComplexF64}(undef, sz)
+    mid = zeros(Float64, sz)
+    linop!(lo, zs[1])
+    dk = selectdim(dΦ, d, 1)
+    @. dk = imag(lo)
+    for k = 1:nz-1
+        linop!(lo, zs[k] + δz/2)
+        @. mid = imag(lo)
+        linop!(lo, zs[k+1])
+        dk = selectdim(dΦ, d, k)
+        dk1 = selectdim(dΦ, d, k+1)
+        @. dk1 = imag(lo)
+        # Simpson over [z[k], z[k+1]]
+        Φk = selectdim(Φ, d, k)
+        Φk1 = selectdim(Φ, d, k+1)
+        @. Φk1 = Φk + δz/6*(dk + 4*mid + dk1)
+    end
+    TabulatedUnitaryPhase(zs, Φ, dΦ)
+end
+
+"Number of tabulation nodes which keeps the two phase tables within `maxbytes`."
+_default_phase_nz(n; maxbytes=64*2^20) = Int(clamp(fld(maxbytes, 16*max(n, 1)), 33, 401))
+
 end

--- a/src/LinearOps.jl
+++ b/src/LinearOps.jl
@@ -523,48 +523,45 @@ end
 (p::ConstUnitaryPhase)(out, z) = (@. out = p.dφ * z; out)
 
 """
-    TabulatedUnitaryPhase(z, Φ, dΦ)
+    TabulatedUnitaryPhase(z, Φ, dΦ, atol, err)
 
 [`AbstractUnitaryPhase`](@ref) for a `z`-dependent linear operator. `Φ` and `dΦ` hold the
-accumulated phase and its derivative `imag(linop)` on the uniform node grid `z`, stacked
-along the last dimension. Between nodes the phase is interpolated with a cubic Hermite, which
-uses both the tabulated value and the tabulated derivative and so matches the accuracy of the
-node integration. Outside `[z[1], z[end]]` it extrapolates linearly, which is needed because
-the integrator overshoots `grid.zmax` on its final step.
+accumulated phase and its derivative `imag(linop)` at the nodes `z`, stacked along the last
+dimension. The nodes are **not** uniformly spaced: they are placed by
+[`unitary_phase`](@ref) so that the interpolation error stays below `atol`, and `err` records
+the largest error actually measured during construction. Between nodes the phase is
+interpolated with a cubic Hermite, which uses both the tabulated value and the tabulated
+derivative. Outside `[z[1], z[end]]` it extrapolates linearly.
 """
 struct TabulatedUnitaryPhase{aT<:AbstractArray} <: AbstractUnitaryPhase
-    z::LinRange{Float64, Int}
+    z::Vector{Float64}
     Φ::aT
     dΦ::aT
+    atol::Float64 # tolerance the nodes were placed to satisfy, in radians
+    err::Float64 # largest interpolation error measured while placing them, in radians
 end
 
 function (p::TabulatedUnitaryPhase)(out, z)
     zs = p.z
-    nz = length(zs)
     d = ndims(p.Φ)
-    if z >= zs[end] # linear extrapolation past the end of the table
-        Φk = selectdim(p.Φ, d, nz)
-        dk = selectdim(p.dΦ, d, nz)
-        δ = z - zs[end]
-        @. out = Φk + dk*δ
-        return out
-    elseif z <= zs[1]
-        Φk = selectdim(p.Φ, d, 1)
-        dk = selectdim(p.dΦ, d, 1)
-        δ = z - zs[1]
+    if z >= zs[end] || z <= zs[1] # linear extrapolation off either end of the table
+        k = z <= zs[1] ? 1 : length(zs)
+        Φk = selectdim(p.Φ, d, k)
+        dk = selectdim(p.dΦ, d, k)
+        δ = z - zs[k]
         @. out = Φk + dk*δ
         return out
     end
-    δz = step(zs)
-    k = min(floor(Int, (z - zs[1])/δz) + 1, nz-1)
-    s = (z - zs[k])/δz
+    k = searchsortedlast(zs, z)
+    h = zs[k+1] - zs[k]
+    s = (z - zs[k])/h
     # cubic Hermite basis
     s2 = s*s
     s3 = s2*s
     h00 = 2s3 - 3s2 + 1
-    h10 = δz*(s3 - 2s2 + s)
+    h10 = h*(s3 - 2s2 + s)
     h01 = -2s3 + 3s2
-    h11 = δz*(s3 - s2)
+    h11 = h*(s3 - s2)
     Φk = selectdim(p.Φ, d, k)
     Φk1 = selectdim(p.Φ, d, k+1)
     dk = selectdim(p.dΦ, d, k)
@@ -574,49 +571,111 @@ function (p::TabulatedUnitaryPhase)(out, z)
 end
 
 """
-    unitary_phase(linop, grid, sz=size(linop); nz=nothing)
+    unitary_phase(linop, grid, sz=size(linop); atol=1e-6, margin=0.05, maxdepth=24, maxnodes=4096)
 
 Create an [`AbstractUnitaryPhase`](@ref) for the linear operator `linop`, which may be either
 a constant array or a mutating function `linop!(out, z)`. `sz` is the size of the array
 `linop!` fills (equal to `size(linop)` in the constant case, and to the size of the noise
 field in general).
 
-For a `z`-dependent `linop!`, the accumulated phase is tabulated on `nz` uniform nodes over
-`[0, grid.zmax]`, each interval integrated by Simpson's rule (so `linop!` is evaluated
-`2nz-1` times in total, once per node and once per midpoint). `nz` defaults to a value chosen
-from a ~64 MB budget for the two tables, clamped to `[33, 401]`.
+A constant `linop` needs no work: `Φ = imag(linop)·z` exactly.
+
+For a `z`-dependent `linop!` the accumulated phase is tabulated by **adaptive bisection**.
+Each candidate interval is integrated with Simpson's rule and then checked against the thing
+that actually matters — the cubic Hermite interpolant that will be used to read the table
+back. The interpolant's error peaks at the interval midpoint, where it is compared against
+the directly integrated value there, and the interval is bisected until that error is at most
+`atol` radians (across every element of `linop`). The largest error that survives is recorded
+in the returned object and reported.
+
+This matters because Luna's `z`-dependent operators are usually *not* smooth. A pressure
+gradient built by [`Capillary.gradient`](@ref Luna.Capillary.gradient) goes as
+`√(p₀² + z/L(p₁² − p₀²))`, which has a `1/√z` cusp in its derivative at the entrance whenever
+`p₀ = 0`, and a multi-section fill has a derivative discontinuity at every junction; tapers
+are whatever function the user supplies. Uniform nodes converge at second order or worse
+across such a feature, and give no way to tell how far off they are. Bisection puts nodes
+only where they are needed — a kink costs a handful of extra intervals rather than a finer
+grid everywhere — so the table is usually *smaller* than a uniform one of equal accuracy.
+
+The table covers `[0, (1 + margin)·zmax]` rather than `[0, zmax]`, because `RK45.solve` runs
+`while tn <= tmax` and so overshoots the end of the fibre on its final step -- and that step's
+stages are what the last saved plane is interpolated from. `linop!` has to be defined a little
+past `zmax` for this, which it already does: `RK45.make_prop!` evaluates it there too.
+Anything beyond the margin still falls back to linear extrapolation.
+
+`maxdepth` and `maxnodes` bound the work if `linop!` is genuinely discontinuous in `z`; if
+either bound stops refinement before `atol` is met, a warning reports the error achieved.
 """
-unitary_phase(linop::AbstractArray, grid, sz=size(linop); nz=nothing) =
+unitary_phase(linop::AbstractArray, grid, sz=size(linop); kwargs...) =
     ConstUnitaryPhase(imag.(linop))
 
-function unitary_phase(linop!, grid, sz; nz=nothing)
-    nz = isnothing(nz) ? _default_phase_nz(prod(sz)) : nz
-    zs = LinRange(0.0, float(grid.zmax), nz)
-    δz = step(zs)
-    Φ = zeros(Float64, (sz..., nz))
-    dΦ = zeros(Float64, (sz..., nz))
-    d = ndims(Φ)
-    lo = Array{ComplexF64}(undef, sz)
-    mid = zeros(Float64, sz)
-    linop!(lo, zs[1])
-    dk = selectdim(dΦ, d, 1)
-    @. dk = imag(lo)
-    for k = 1:nz-1
-        linop!(lo, zs[k] + δz/2)
-        @. mid = imag(lo)
-        linop!(lo, zs[k+1])
-        dk = selectdim(dΦ, d, k)
-        dk1 = selectdim(dΦ, d, k+1)
-        @. dk1 = imag(lo)
-        # Simpson over [z[k], z[k+1]]
-        Φk = selectdim(Φ, d, k)
-        Φk1 = selectdim(Φ, d, k+1)
-        @. Φk1 = Φk + δz/6*(dk + 4*mid + dk1)
+function unitary_phase(linop!, grid, sz; atol=1e-6, margin=0.05, maxdepth=24, maxnodes=4096)
+    N = length(sz)
+    buf = Array{ComplexF64}(undef, sz)
+    neval = Ref(0)
+    dat = function (z)
+        neval[] += 1
+        linop!(buf, z)
+        imag.(buf)
     end
-    TabulatedUnitaryPhase(zs, Φ, dΦ)
+    zmax = float(grid.zmax)*(1 + margin)
+    znodes = Float64[0.0]
+    dnodes = Array{Float64, N}[dat(0.0)]
+    deltas = Array{Float64, N}[] # accumulated phase across each accepted interval
+    worst = Ref(0.0)
+    _refine!(znodes, dnodes, deltas, worst, dat, 0.0, zmax, dnodes[1], dat(zmax), nothing,
+             atol, 0, maxdepth, maxnodes)
+
+    n = length(znodes)
+    Φ = zeros(Float64, (sz..., n))
+    dΦ = zeros(Float64, (sz..., n))
+    d = N + 1
+    selectdim(dΦ, d, 1) .= dnodes[1]
+    for k = 2:n
+        selectdim(Φ, d, k) .= selectdim(Φ, d, k-1) .+ deltas[k-1]
+        selectdim(dΦ, d, k) .= dnodes[k]
+    end
+    if worst[] > atol
+        @warn("Noise phase table did not reach its tolerance: $n nodes, "*
+              "max interpolation error $(worst[]) rad against a tolerance of $atol rad. "*
+              "The linear operator may be discontinuous in z.")
+    else
+        @info("Noise phase table: $n nodes, $(neval[]) linop evaluations, "*
+              "max interpolation error $(worst[]) rad.")
+    end
+    TabulatedUnitaryPhase(znodes, Φ, dΦ, float(atol), worst[])
 end
 
-"Number of tabulation nodes which keeps the two phase tables within `maxbytes`."
-_default_phase_nz(n; maxbytes=64*2^20) = Int(clamp(fld(maxbytes, 16*max(n, 1)), 33, 401))
+#= Bisect [a, b] until the cubic Hermite interpolant built from the endpoint values and
+   derivatives is within atol of the true phase at the midpoint, which is where its error
+   peaks. `dmid` is the already-evaluated derivative at the midpoint, if the caller has it
+   (a bisection's two children each inherit one of the parent's quarter points), so each
+   call costs two new evaluations of linop rather than three. =#
+function _refine!(znodes, dnodes, deltas, worst, dat, a, b, da, db, dmid,
+                  atol, depth, maxdepth, maxnodes)
+    h = b - a
+    m = a + h/2
+    dm = isnothing(dmid) ? dat(m) : dmid
+    dq1 = dat(a + h/4)
+    dq2 = dat(a + 3h/4)
+    ΔΦ = @. h/12*(da + 4dq1 + 2dm + 4dq2 + db) # Φ(b) - Φ(a), Simpson on each half
+    err = 0.0
+    for i in eachindex(ΔΦ)
+        hermite = ΔΦ[i]/2 + h*(da[i] - db[i])/8 # Hermite at the midpoint, minus Φ(a)
+        exact = h/12*(da[i] + 4dq1[i] + dm[i]) # Simpson over [a, m]
+        err = max(err, abs(hermite - exact))
+    end
+    if err <= atol || depth >= maxdepth || length(znodes) >= maxnodes
+        push!(znodes, b)
+        push!(dnodes, db)
+        push!(deltas, ΔΦ)
+        worst[] = max(worst[], err)
+        return
+    end
+    _refine!(znodes, dnodes, deltas, worst, dat, a, m, da, dm, dq1,
+             atol, depth+1, maxdepth, maxnodes)
+    _refine!(znodes, dnodes, deltas, worst, dat, m, b, dm, db, dq2,
+             atol, depth+1, maxdepth, maxnodes)
+end
 
 end

--- a/src/Luna.jl
+++ b/src/Luna.jl
@@ -114,14 +114,14 @@ end
 
 function setup(grid::Grid.RealGrid, densityfun, responses, inputs, βfun!, aeff;
                norm! = NonlinearRHS.norm_mode_average(grid, βfun!, aeff),
-               noise_field=nothing)
+               noise=nothing)
     Logging.@info("Setting up and planning FFTs...")
     flush(stderr)
     Utils.loadFFTwisdom()
     xo = Array{Float64}(undef, length(grid.to))
     FTo = FFTW.plan_rfft(xo, 1, flags=settings["fftw_flag"])
     transform = NonlinearRHS.TransModeAvg(grid, FTo, responses, densityfun, norm!, aeff;
-                                          noise_field)
+                                          noise)
     x = Array{Float64}(undef, length(grid.t))
     FT = FFTW.plan_rfft(x, 1, flags=settings["fftw_flag"])
     Eω = doinput_sm(grid, inputs, FT)
@@ -135,7 +135,7 @@ end
 
 function setup(grid::Grid.EnvGrid, densityfun, responses, inputs, βfun!, aeff;
                norm! = NonlinearRHS.norm_mode_average(grid, βfun!, aeff),
-               noise_field=nothing)
+               noise=nothing)
     Logging.@info("Setting up and planning FFTs...")
     flush(stderr)
     Utils.loadFFTwisdom()
@@ -144,7 +144,7 @@ function setup(grid::Grid.EnvGrid, densityfun, responses, inputs, βfun!, aeff;
     xo = Array{ComplexF64}(undef, length(grid.to))
     FTo = FFTW.plan_fft(xo, 1, flags=settings["fftw_flag"])
     transform = NonlinearRHS.TransModeAvg(grid, FTo, responses, densityfun, norm!, aeff;
-                                          noise_field)
+                                          noise)
     Eω = doinput_sm(grid, inputs, FT)
     inv(FT) # create inverse FT plans now, so wisdom is saved
     inv(FTo)
@@ -177,7 +177,7 @@ end
 function setup(grid::Grid.RealGrid, densityfun, responses, inputs,
                modes::Modes.ModeCollection, components;
                full=false, norm! = NonlinearRHS.norm_modal(grid),
-               rtol=1e-3, atol=0.0, mfcn=512, noise_field=nothing)
+               rtol=1e-3, atol=0.0, mfcn=512, noise=nothing)
     Logging.@info("Setting up and planning FFTs...")
     flush(stderr)
     ts = Modes.ToSpace(modes, components=components)
@@ -192,7 +192,7 @@ function setup(grid::Grid.RealGrid, densityfun, responses, inputs,
     FTo = FFTW.plan_rfft(xo, 1, flags=settings["fftw_flag"])
     transform = NonlinearRHS.TransModal(grid, ts, FTo,
                                  responses, densityfun, norm!;
-                                 rtol, atol, mfcn, full, noise_field)
+                                 rtol, atol, mfcn, full, noise)
     inv(FT) # create inverse FT plans now, so wisdom is saved
     inv(FTo)
     Utils.saveFFTwisdom()
@@ -204,7 +204,7 @@ end
 function setup(grid::Grid.EnvGrid, densityfun, responses, inputs,
                modes::Modes.ModeCollection, components;
                full=false, norm! = NonlinearRHS.norm_modal(grid),
-               rtol=1e-3, atol=0.0, mfcn=512, noise_field=nothing)
+               rtol=1e-3, atol=0.0, mfcn=512, noise=nothing)
     Logging.@info("Setting up and planning FFTs...")
     flush(stderr)
     ts = Modes.ToSpace(modes, components=components)
@@ -219,7 +219,7 @@ function setup(grid::Grid.EnvGrid, densityfun, responses, inputs,
     FTo = FFTW.plan_fft(xo, 1, flags=settings["fftw_flag"])
     transform = NonlinearRHS.TransModal(grid, ts, FTo,
                                  responses, densityfun, norm!;
-                                 rtol, atol, mfcn, full, noise_field)
+                                 rtol, atol, mfcn, full, noise)
     inv(FT) # create inverse FT plans now, so wisdom is saved
     inv(FTo)
     Utils.saveFFTwisdom()
@@ -241,7 +241,7 @@ function doinputs_fs!(Eωk, grid, spacegrid::Union{Hankel.QDHT,Grid.FreeGrid}, F
 end
 
 function setup(grid::Grid.RealGrid, q::Hankel.QDHT,
-               densityfun, normfun, responses, inputs; noise_field=nothing)
+               densityfun, normfun, responses, inputs; noise=nothing)
     Logging.@info("Setting up and planning FFTs...")
     flush(stderr)
     Utils.loadFFTwisdom()
@@ -253,7 +253,7 @@ function setup(grid::Grid.RealGrid, q::Hankel.QDHT,
     xo = Array{Float64}(undef, length(grid.to), length(q.r))
     FTo = FFTW.plan_rfft(xo, 1, flags=settings["fftw_flag"])
     transform = NonlinearRHS.TransRadial(grid, q, FTo, responses, densityfun, normfun;
-                                         noise_field)
+                                         noise)
     inv(FT) # create inverse FT plans now, so wisdom is saved
     inv(FTo)
     Utils.saveFFTwisdom()
@@ -263,7 +263,7 @@ function setup(grid::Grid.RealGrid, q::Hankel.QDHT,
 end
 
 function setup(grid::Grid.EnvGrid, q::Hankel.QDHT,
-               densityfun, normfun, responses, inputs; noise_field=nothing)
+               densityfun, normfun, responses, inputs; noise=nothing)
     Logging.@info("Setting up and planning FFTs...")
     flush(stderr)
     Utils.loadFFTwisdom()
@@ -275,7 +275,7 @@ function setup(grid::Grid.EnvGrid, q::Hankel.QDHT,
     xo = Array{ComplexF64}(undef, length(grid.to), length(q.r))
     FTo = FFTW.plan_fft(xo, 1, flags=settings["fftw_flag"])
     transform = NonlinearRHS.TransRadial(grid, q, FTo, responses, densityfun, normfun;
-                                         noise_field)
+                                         noise)
     inv(FT) # create inverse FT plans now, so wisdom is saved
     inv(FTo)
     Utils.saveFFTwisdom()
@@ -285,7 +285,7 @@ function setup(grid::Grid.EnvGrid, q::Hankel.QDHT,
 end
 
 function setup(grid::Grid.RealGrid, xygrid::Grid.FreeGrid,
-               densityfun, normfun, responses, inputs; noise_field=nothing)
+               densityfun, normfun, responses, inputs; noise=nothing)
     Logging.@info("Setting up and planning FFTs...")
     flush(stderr)
     Utils.loadFFTwisdom()
@@ -299,7 +299,7 @@ function setup(grid::Grid.RealGrid, xygrid::Grid.FreeGrid,
     FTo = FFTW.plan_rfft(xo, (1, 2, 3), flags=settings["fftw_flag"])
     transform = NonlinearRHS.TransFree(grid, xygrid, FTo,
                                        responses, densityfun, normfun;
-                                       noise_field)
+                                       noise)
     inv(FT) # create inverse FT plans now, so wisdom is saved
     inv(FTo)
     Utils.saveFFTwisdom()
@@ -309,7 +309,7 @@ function setup(grid::Grid.RealGrid, xygrid::Grid.FreeGrid,
 end
 
 function setup(grid::Grid.EnvGrid, xygrid::Grid.FreeGrid,
-               densityfun, normfun, responses, inputs; noise_field=nothing)
+               densityfun, normfun, responses, inputs; noise=nothing)
     Logging.@info("Setting up and planning FFTs...")
     flush(stderr)
     Utils.loadFFTwisdom()
@@ -323,7 +323,7 @@ function setup(grid::Grid.EnvGrid, xygrid::Grid.FreeGrid,
     FTo = FFTW.plan_fft(xo, (1, 2, 3), flags=settings["fftw_flag"])
     transform = NonlinearRHS.TransFree(grid, xygrid, FTo,
                                        responses, densityfun, normfun;
-                                       noise_field)
+                                       noise)
     inv(FT) # create inverse FT plans now, so wisdom is saved
     inv(FTo)
     Utils.saveFFTwisdom()

--- a/src/NonlinearRHS.jl
+++ b/src/NonlinearRHS.jl
@@ -147,19 +147,87 @@ function Et_to_Pt!(Pt, Et, responses, density, idcs)
 end
 
 """
+    ModifiedNoise(Eω_noise, phase, grid)
+
+The noise field of the modified shot-noise model (Chen & Wise, arXiv:2410.20567) together
+with the propagator which advances it in `z`.
+
+`Eω_noise` is the one-photon-per-mode spectral draw from
+[`Fields.generate_noise_field`](@ref Luna.Fields.generate_noise_field), made once before
+propagation and never re-randomised. `phase` is an
+[`AbstractUnitaryPhase`](@ref Luna.LinearOps.AbstractUnitaryPhase), created with
+[`LinearOps.unitary_phase`](@ref Luna.LinearOps.unitary_phase), which supplies the
+accumulated phase `Φ(ω, z) = ∫₀ᶻ imag(linop) dz'`.
+
+The noise is advanced by the **unitary** part of the linear operator only:
+
+- **dispersion — yes.** It is unitary, and it is the phase evolution of the medium's own
+  vacuum modes. Without it the model is not related to the traditional (`:input`) model by
+  the identity `A_s = A_s' + A_noise` on which it rests, and Kerr/FWM magnitudes are wrong by
+  up to ~6× per frequency (much more in conservative propagation).
+- **loss — no.** Fluctuation–dissipation: loss replenishes vacuum rather than removing it, so
+  the local noise level stays at one photon per mode. This is also what allows the model to
+  seed spontaneous generation in absorptive media.
+- **gain — no.** The source term already injects fresh vacuum at every `z`, which the
+  homogeneous propagator amplifies over the remaining length — that integral *is* the ASE.
+  Amplifying the noise as well double-counts it.
+
+Because the field is drawn once and only ever propagated deterministically, results remain
+step-size independent, which is what the "constant noise field" requirement of the paper
+actually protects.
+
+The draw is multiplied by `grid.ωwin` on construction, matching the windowing the traditional
+input shot noise receives from the propagation loop.
+"""
+struct ModifiedNoise{aT, pT, bT}
+    Eω0::aT # z = 0 spectral draw (windowed)
+    phase::pT # accumulated unitary phase of the linear operator
+    φ::bT # buffer for Φ(ω, z)
+    Eω::aT # buffer holding the propagated spectral noise
+    lastz::Base.RefValue{Float64}
+end
+
+function ModifiedNoise(Eω_noise, phase, grid)
+    Eω0 = Eω_noise .* grid.ωwin
+    ModifiedNoise(Eω0, phase, zeros(Float64, size(Eω0)), similar(Eω0), Ref(NaN))
+end
+
+"""
+    noise_at!(noise::ModifiedNoise, z)
+
+Fill and return the propagated spectral noise field at `z`. The result aliases an internal
+buffer, so copy it if it needs to outlive the next call.
+"""
+function noise_at!(n::ModifiedNoise, z)
+    if z != n.lastz[]
+        n.phase(n.φ, z)
+        @. n.Eω = n.Eω0 * cis(n.φ)
+        n.lastz[] = z
+    end
+    n.Eω
+end
+
+"""
+    noise_at(noise::ModifiedNoise, z)
+
+As [`noise_at!`](@ref) but returns a fresh array.
+"""
+noise_at(n::ModifiedNoise, z) = copy(noise_at!(n, z))
+
+"""
     TransModal
 
 Transform E(ω) -> Pₙₗ(ω) for multimode propagation via spatial integration.
 
 # Fields
-- `Emω_noise`: modal noise field `(nω, nmodes)` for the modified shot-noise model, or
-  `nothing`. When present, the noise is projected to real space at each integration point
-  and combined with the field in a separate buffer (`Er_nl`) for nonlinear evaluation.
-  The propagating field (`Er`) is never modified.
+- `noise`: [`ModifiedNoise`](@ref) for the modified shot-noise model, or `nothing`. It is
+  advanced to the current `z` once per call, in `reset!`, and then projected to real space at
+  each integration point and combined with the field in a separate buffer (`Er_nl`) for
+  nonlinear evaluation. The propagating field (`Er`) is never modified.
 - `Er_noise`: preallocated buffer for the real-space time-domain noise, same shape as `Er`.
 - `Er_nl`: preallocated buffer for the combined field + noise, passed to `Et_to_Pt!`.
 """
-mutable struct TransModal{tsT, lT, TT, FTT, rT, gT, dT, ddT, nT, eT, enT, enlT}
+mutable struct TransModal{tsT, lT, TT, FTT, rT, gT, dT, ddT, nT, nsT, enT, enlT}
     ts::tsT
     full::Bool
     dimlimits::lT
@@ -183,7 +251,7 @@ mutable struct TransModal{tsT, lT, TT, FTT, rT, gT, dT, ddT, nT, eT, enT, enlT}
     atol::Float64
     mfcn::Int
     err::Array{ComplexF64,2}
-    Emω_noise::eT # modal noise field for modified shot-noise model, or nothing
+    noise::nsT # ModifiedNoise for the modified shot-noise model, or nothing
     Er_noise::enT # buffer for real-space time-domain noise, or nothing
     Er_nl::enlT # buffer for field+noise passed to Et_to_Pt!, or nothing
 end
@@ -201,7 +269,7 @@ function show(io::IO, t::TransModal)
 end
 
 """
-    TransModal(grid, ts, FT, resp, densityfun, norm!; rtol=1e-3, atol=0.0, mfcn=300, full=false, noise_field=nothing)
+    TransModal(grid, ts, FT, resp, densityfun, norm!; rtol=1e-3, atol=0.0, mfcn=300, full=false, noise=nothing)
 
 Construct a `TransModal`, transform E(ω) -> Pₙₗ(ω) for modal fields.
 
@@ -216,12 +284,11 @@ Construct a `TransModal`, transform E(ω) -> Pₙₗ(ω) for modal fields.
 - `atol::Float=0.0` : absolute tolerance on the `HCubature` integration
 - `mfcn::Int=512` : maximum number of function evaluations for one modal integration
 - `full::Bool=false` : if `true`, use full 2-D mode integral, if `false`, only do radial integral
-- `noise_field=nothing` : optional `(nω, nmodes)` noise field for the modified shot-noise
-  model. Each mode column should contain independent noise with the one-photon-per-mode
-  spectral density. Generate with [`Fields.generate_noise_field`](@ref Luna.Fields.generate_noise_field).
+- `noise=nothing` : optional [`ModifiedNoise`](@ref) for the modified shot-noise model, whose
+  `(nω, nmodes)` draw holds independent one-photon-per-mode noise in each mode column.
 """
 function TransModal(tT, grid, ts::Modes.ToSpace, FT, resp, densityfun, norm!;
-                    rtol=1e-3, atol=0.0, mfcn=512, full=false, noise_field=nothing)
+                    rtol=1e-3, atol=0.0, mfcn=512, full=false, noise=nothing)
     Emω = Array{ComplexF64,2}(undef, length(grid.ω), ts.nmodes)
     Erω = Array{ComplexF64,2}(undef, length(grid.ω), ts.npol)
     Erωo = Array{ComplexF64,2}(undef, length(grid.ωo), ts.npol)
@@ -231,21 +298,19 @@ function TransModal(tT, grid, ts::Modes.ToSpace, FT, resp, densityfun, norm!;
     Prωo = Array{ComplexF64,2}(undef, length(grid.ωo), ts.npol)
     Prmω = Array{ComplexF64,2}(undef, length(grid.ω), ts.nmodes)
     IFT = inv(FT)
-    # For the modified shot-noise model, store the modal noise field and allocate a buffer
-    # for the real-space time-domain noise. The noise is projected to space at each
-    # integration point in Erω_to_Prω!, so we store it in the modal domain.
-    if !isnothing(noise_field)
-        Emω_noise = copy(noise_field)
+    # For the modified shot-noise model, allocate a buffer for the modal noise field at the
+    # current z and one for the real-space time-domain noise. The noise is projected to space
+    # at each integration point in Erω_to_Prω!, so we hold it in the modal domain.
+    if !isnothing(noise)
         Er_noise = Array{tT,2}(undef, length(grid.to), ts.npol)
         Er_nl = Array{tT,2}(undef, length(grid.to), ts.npol)
     else
-        Emω_noise = nothing
         Er_noise = nothing
         Er_nl = nothing
     end
     TransModal(ts, full, Modes.dimlimits(ts.ms[1]), Emω, Erω, Erωo, Er, Pr, Prω, Prωo, Prmω,
                FT, resp, grid, densityfun, densityfun(0.0), norm!, 0, 0.0, rtol, atol, mfcn,
-               similar(Prmω), Emω_noise, Er_noise, Er_nl)
+               similar(Prmω), noise, Er_noise, Er_nl)
 end
 
 function TransModal(grid::Grid.RealGrid, args...; kwargs...)
@@ -262,6 +327,9 @@ function reset!(t::TransModal, Emω::Array{ComplexF64,2}, z::Float64)
     t.z = z
     t.dimlimits = Modes.dimlimits(t.ts.ms[1], z=z)
     t.density = t.densityfun(z)
+    # Advance the modified shot-noise field to this z. Done once per RHS evaluation rather
+    # than at every cubature point, which is why this path costs essentially nothing.
+    isnothing(t.noise) || noise_at!(t.noise, z)
 end
 
 function pointcalc!(fval, xs, t::TransModal)
@@ -306,11 +374,12 @@ end
 function Erω_to_Prω!(t, x)
     Modes.to_space!(t.Erω, t.Emω, x, t.ts, z=t.z)
     to_time!(t.Er, t.Erω, t.Erωo, inv(t.FT))
-    # Modified shot-noise model: project noise modes to real space at this spatial point,
-    # convert to oversampled time domain, and combine with field in a separate buffer (Er_nl)
-    # so the propagating field (Er) is never contaminated.
-    if !isnothing(t.Emω_noise)
-        Modes.to_space!(t.Erω, t.Emω_noise, x, t.ts, z=t.z)
+    # Modified shot-noise model: project the noise modes (already advanced to t.z by reset!)
+    # to real space at this spatial point, convert to the oversampled time domain, and
+    # combine with the field in a separate buffer (Er_nl) so the propagating field (Er) is
+    # never contaminated.
+    if !isnothing(t.noise)
+        Modes.to_space!(t.Erω, t.noise.Eω, x, t.ts, z=t.z)
         to_time!(t.Er_noise, t.Erω, t.Erωo, inv(t.FT))
         @. t.Er_nl = t.Er + t.Er_noise
         Et_to_Pt!(t.Pr, t.Er_nl, t.resp, t.density)
@@ -363,13 +432,16 @@ end
 Transform E(ω) -> Pₙₗ(ω) for mode-averaged single-mode propagation.
 
 # Fields
-- `Et_noise`: precomputed time-domain noise on the oversampled grid for the modified
-  shot-noise model (Chen & Wise, arXiv:2410.20567), or `nothing` for the traditional model.
-- `Et_nl`: preallocated buffer for the combined field + noise. When `Et_noise` is present,
+- `noise`: [`ModifiedNoise`](@ref) for the modified shot-noise model (Chen & Wise,
+  arXiv:2410.20567), or `nothing` for the traditional model.
+- `Eωo_noise`/`Et_noise`: buffers holding the noise field at the current `z`, on the
+  oversampled frequency and time grids.
+- `Et_nl`: preallocated buffer for the combined field + noise. When `noise` is present,
   `Et_nl = Eto + Et_noise` is computed at each step and passed to `Et_to_Pt!`. The
-  propagating field (`Eto`) is never modified; dispersion acts only on the physical field.
+  propagating field (`Eto`) is never modified: the noise feels only the unitary part of the
+  linear operator, and never the loss.
 """
-struct TransModeAvg{TT, FTT, rT, gT, dT, nT, aT, eT, nlT}
+struct TransModeAvg{TT, FTT, rT, gT, dT, nT, aT, nsT, eoT, eT, nlT}
     Pto::Vector{TT}
     Eto::Vector{TT}
     Eωo::Vector{ComplexF64}
@@ -380,7 +452,9 @@ struct TransModeAvg{TT, FTT, rT, gT, dT, nT, aT, eT, nlT}
     densityfun::dT
     norm!::nT
     aeff::aT # function which returns effective area
-    Et_noise::eT # time-domain noise for modified shot-noise model, or nothing
+    noise::nsT # ModifiedNoise for the modified shot-noise model, or nothing
+    Eωo_noise::eoT # buffer for the oversampled spectral noise at the current z, or nothing
+    Et_noise::eT # buffer for the time-domain noise at the current z, or nothing
     Et_nl::nlT # buffer for field+noise passed to Et_to_Pt!, or nothing
 end
 
@@ -393,34 +467,31 @@ function show(io::IO, t::TransModeAvg)
 end
 
 """
-    TransModeAvg(TT, grid, FT, resp, densityfun, norm!, aeff; noise_field=nothing)
+    TransModeAvg(TT, grid, FT, resp, densityfun, norm!, aeff; noise=nothing)
 
 Construct a `TransModeAvg` transform for mode-averaged propagation.
 
 # Keyword arguments
-- `noise_field=nothing`: optional frequency-domain noise field (on the normal grid) for the
-  modified shot-noise model. When provided, it is converted to the oversampled time grid and
-  stored as `Et_noise` for injection into the nonlinear operator at every propagation step.
-  Generate with [`Fields.generate_noise_field`](@ref Luna.Fields.generate_noise_field).
+- `noise=nothing`: optional [`ModifiedNoise`](@ref) for the modified shot-noise model. When
+  provided, the noise field is advanced to the current `z`, converted to the oversampled time
+  grid, and injected into the nonlinear operator at every propagation step.
 """
-function TransModeAvg(TT, grid, FT, resp, densityfun, norm!, aeff; noise_field=nothing)
+function TransModeAvg(TT, grid, FT, resp, densityfun, norm!, aeff; noise=nothing)
     Eωo = zeros(ComplexF64, length(grid.ωo))
     Eto = zeros(TT, length(grid.to))
     Pto = similar(Eto)
     Pωo = similar(Eωo)
-    # Precompute time-domain noise on the oversampled grid if noise_field is provided.
-    # Uses the same ω→t conversion path as to_time!: copy_scale! into oversampled spectral
-    # array, then inverse FFT. The result is constant throughout propagation.
-    if !isnothing(noise_field)
+    if !isnothing(noise)
         Eωo_noise = zeros(ComplexF64, length(grid.ωo))
         Et_noise = zeros(TT, length(grid.to))
-        to_time!(Et_noise, noise_field, Eωo_noise, inv(FT))
         Et_nl = zeros(TT, length(grid.to))
     else
+        Eωo_noise = nothing
         Et_noise = nothing
         Et_nl = nothing
     end
-    TransModeAvg(Pto, Eto, Eωo, Pωo, FT, resp, grid, densityfun, norm!, aeff, Et_noise, Et_nl)
+    TransModeAvg(Pto, Eto, Eωo, Pωo, FT, resp, grid, densityfun, norm!, aeff,
+                 noise, Eωo_noise, Et_noise, Et_nl)
 end
 
 function TransModeAvg(grid::Grid.RealGrid, FT, resp, densityfun, norm!, aeff; kwargs...)
@@ -437,10 +508,12 @@ function (t::TransModeAvg)(nl, Eω, z)
     to_time!(t.Eto, Eω, t.Eωo, inv(t.FT))
     sc = nlscale*sqrt(t.aeff(z))
     @. t.Eto /= sc
-    # Modified shot-noise model: compute field+noise in a separate buffer (Et_nl) so that
-    # the propagating field (Eto) is never contaminated. The noise is scaled by the same
-    # normalisation factor (nlscale × √Aeff) so it enters in physical units.
-    if !isnothing(t.Et_noise)
+    # Modified shot-noise model: advance the noise to this z, then compute field+noise in a
+    # separate buffer (Et_nl) so that the propagating field (Eto) is never contaminated. The
+    # noise is scaled by the same normalisation factor (nlscale × √Aeff) so it enters in
+    # physical units.
+    if !isnothing(t.noise)
+        to_time!(t.Et_noise, noise_at!(t.noise, z), t.Eωo_noise, inv(t.FT))
         @. t.Et_nl = t.Eto + t.Et_noise / sc
         Et_to_Pt!(t.Pto, t.Et_nl, t.resp, t.densityfun(z))
     else
@@ -487,12 +560,13 @@ end
 Transform E(ω) -> Pₙₗ(ω) for radially symmetric free-space propagation.
 
 # Fields
-- `Et_noise`: precomputed time-domain noise on the oversampled real-space grid `(nto, nr)`
-  for the modified shot-noise model, or `nothing`.
+- `noise`: [`ModifiedNoise`](@ref) for the modified shot-noise model, or `nothing`.
+- `Eωo_noise`/`Et_noise`: buffers holding the noise field at the current `z`, on the
+  oversampled frequency/k-space and time/real-space grids `(nto, nr)`.
 - `Et_nl`: preallocated buffer for the combined field + noise, passed to `Et_to_Pt!`. The
   propagating field (`Eto`) is never modified.
 """
-struct TransRadial{TT, HTT, FTT, nT, rT, gT, dT, iT, eT, nlT}
+struct TransRadial{TT, HTT, FTT, nT, rT, gT, dT, iT, nsT, eoT, eT, nlT}
     QDHT::HTT # Hankel transform (space to k-space)
     FT::FTT # Fourier transform (time to frequency)
     normfun::nT # Function which returns normalisation factor
@@ -504,7 +578,9 @@ struct TransRadial{TT, HTT, FTT, nT, rT, gT, dT, iT, eT, nlT}
     Eωo::Array{ComplexF64,2} # Buffer array for field on oversampled frequency grid
     Pωo::Array{ComplexF64,2} # Buffer array for NL polarisation on oversampled frequency grid
     idcs::iT # CartesianIndices for Et_to_Pt! to iterate over
-    Et_noise::eT # time-domain noise for modified shot-noise model, or nothing
+    noise::nsT # ModifiedNoise for the modified shot-noise model, or nothing
+    Eωo_noise::eoT # buffer for the oversampled spectral noise at the current z, or nothing
+    Et_noise::eT # buffer for the time-domain noise at the current z, or nothing
     Et_nl::nlT # buffer for field+noise passed to Et_to_Pt!, or nothing
 end
 
@@ -519,34 +595,33 @@ function show(io::IO, t::TransRadial)
 end
 
 """
-    TransRadial(TT, grid, HT, FT, responses, densityfun, normfun; noise_field=nothing)
+    TransRadial(TT, grid, HT, FT, responses, densityfun, normfun; noise=nothing)
 
 Construct a `TransRadial` to calculate the reciprocal-domain nonlinear polarisation.
 
 # Keyword arguments
-- `noise_field=nothing`: optional `(nω, nk)` frequency/k-space noise field for the modified
-  shot-noise model. When provided, it is converted to the real-space time domain `(nto, nr)`
-  via inverse FFT and inverse Hankel transform, and stored as `Et_noise`.
-  Generate with [`Fields.generate_noise_field`](@ref Luna.Fields.generate_noise_field).
+- `noise=nothing`: optional [`ModifiedNoise`](@ref) for the modified shot-noise model, whose
+  draw is an `(nω, nk)` frequency/k-space noise field. At each step it is advanced to the
+  current `z` and converted to the real-space time domain `(nto, nr)` via inverse FFT and
+  inverse Hankel transform.
 """
-function TransRadial(TT, grid, HT, FT, responses, densityfun, normfun; noise_field=nothing)
+function TransRadial(TT, grid, HT, FT, responses, densityfun, normfun; noise=nothing)
     Eωo = zeros(ComplexF64, (length(grid.ωo), HT.N))
     Eto = zeros(TT, (length(grid.to), HT.N))
     Pto = similar(Eto)
     Pωo = similar(Eωo)
     idcs = CartesianIndices(size(Pto)[2:end])
-    # Precompute time-domain noise in real space: ω→t via to_time!, then k→r via QDHT⁻¹
-    if !isnothing(noise_field)
+    if !isnothing(noise)
         Eωo_noise = zeros(ComplexF64, (length(grid.ωo), HT.N))
         Et_noise = zeros(TT, (length(grid.to), HT.N))
-        to_time!(Et_noise, noise_field, Eωo_noise, inv(FT))
-        ldiv!(Et_noise, HT, Et_noise)
         Et_nl = zeros(TT, (length(grid.to), HT.N))
     else
+        Eωo_noise = nothing
         Et_noise = nothing
         Et_nl = nothing
     end
-    TransRadial(HT, FT, normfun, responses, grid, densityfun, Pto, Eto, Eωo, Pωo, idcs, Et_noise, Et_nl)
+    TransRadial(HT, FT, normfun, responses, grid, densityfun, Pto, Eto, Eωo, Pωo, idcs,
+                noise, Eωo_noise, Et_noise, Et_nl)
 end
 
 function TransRadial(grid::Grid.RealGrid, args...; kwargs...)
@@ -566,9 +641,12 @@ place the result in `nl`
 function (t::TransRadial)(nl, Eω, z)
     to_time!(t.Eto, Eω, t.Eωo, inv(t.FT)) # transform ω -> t
     ldiv!(t.Eto, t.QDHT, t.Eto) # transform k -> r
-    # Modified shot-noise: compute field+noise in separate buffer (Et_nl) so the
-    # propagating field (Eto) is never contaminated.
-    if !isnothing(t.Et_noise)
+    # Modified shot-noise: advance the noise to this z (ω→t, then k→r) and compute
+    # field+noise in a separate buffer (Et_nl) so the propagating field (Eto) is never
+    # contaminated.
+    if !isnothing(t.noise)
+        to_time!(t.Et_noise, noise_at!(t.noise, z), t.Eωo_noise, inv(t.FT))
+        ldiv!(t.Et_noise, t.QDHT, t.Et_noise)
         @. t.Et_nl = t.Eto + t.Et_noise
         Et_to_Pt!(t.Pto, t.Et_nl, t.resp, t.densityfun(z), t.idcs)
     else
@@ -636,12 +714,13 @@ end
 Transform E(ω) -> Pₙₗ(ω) for 3D free-space propagation.
 
 # Fields
-- `Et_noise`: precomputed time-domain noise on the oversampled real-space grid `(nto, ny, nx)`
-  for the modified shot-noise model, or `nothing`.
+- `noise`: [`ModifiedNoise`](@ref) for the modified shot-noise model, or `nothing`.
+- `Eωo_noise`/`Et_noise`: buffers holding the noise field at the current `z`, on the
+  oversampled frequency/k-space and time/real-space grids `(nto, ny, nx)`.
 - `Et_nl`: preallocated buffer for the combined field + noise, passed to `Et_to_Pt!`. The
   propagating field (`Eto`) is never modified.
 """
-mutable struct TransFree{TT, FTT, nT, rT, gT, xygT, dT, iT, eT, nlT}
+mutable struct TransFree{TT, FTT, nT, rT, gT, xygT, dT, iT, nsT, eoT, eT, nlT}
     FT::FTT # 3D Fourier transform (space to k-space and time to frequency)
     normfun::nT # Function which returns normalisation factor
     resp::rT # nonlinear responses (tuple of callables)
@@ -654,7 +733,9 @@ mutable struct TransFree{TT, FTT, nT, rT, gT, xygT, dT, iT, eT, nlT}
     Pωo::Array{ComplexF64, 3} # buffer for oversampled frequency-domain NL polarisation
     scale::Float64 # scale factor to be applied during oversampling
     idcs::iT # iterating over these slices Eto/Pto into Vectors, one at each position
-    Et_noise::eT # time-domain noise for modified shot-noise model, or nothing
+    noise::nsT # ModifiedNoise for the modified shot-noise model, or nothing
+    Eωo_noise::eoT # buffer for the oversampled spectral noise at the current z, or nothing
+    Et_noise::eT # buffer for the time-domain noise at the current z, or nothing
     Et_nl::nlT # buffer for field+noise passed to Et_to_Pt!, or nothing
 end
 
@@ -669,19 +750,19 @@ function show(io::IO, t::TransFree)
 end
 
 """
-    TransFree(TT, scale, grid, xygrid, FT, responses, densityfun, normfun; noise_field=nothing)
+    TransFree(TT, scale, grid, xygrid, FT, responses, densityfun, normfun; noise=nothing)
 
 Construct a `TransFree` to calculate the reciprocal-domain nonlinear polarisation for 3D
 free-space propagation.
 
 # Keyword arguments
-- `noise_field=nothing`: optional `(nω, ny, nx)` frequency/k-space noise field for the
-  modified shot-noise model. When provided, it is converted to the real-space oversampled
-  time domain `(nto, ny, nx)` via `copy_scale!` and 3D inverse FFT, and stored as `Et_noise`.
-  Generate with [`Fields.generate_noise_field`](@ref Luna.Fields.generate_noise_field).
+- `noise=nothing`: optional [`ModifiedNoise`](@ref) for the modified shot-noise model, whose
+  draw is an `(nω, ny, nx)` frequency/k-space noise field. At each step it is advanced to the
+  current `z` and converted to the real-space oversampled time domain `(nto, ny, nx)` via
+  `copy_scale!` and a 3D inverse FFT.
 """
 function TransFree(TT, scale, grid, xygrid, FT, responses, densityfun, normfun;
-                   noise_field=nothing)
+                   noise=nothing)
     Ny = length(xygrid.y)
     Nx = length(xygrid.x)
     Eωo = zeros(ComplexF64, (length(grid.ωo), Ny, Nx))
@@ -689,21 +770,17 @@ function TransFree(TT, scale, grid, xygrid, FT, responses, densityfun, normfun;
     Pto = similar(Eto)
     Pωo = similar(Eωo)
     idcs = CartesianIndices((Ny, Nx))
-    # Precompute time-domain noise in real space:
-    # copy_scale! into oversampled spectral grid, then 3D IFFT: (ω,ky,kx) → (t,y,x)
-    if !isnothing(noise_field)
+    if !isnothing(noise)
         Eωo_noise = zeros(ComplexF64, (length(grid.ωo), Ny, Nx))
-        N = length(grid.ω)
-        copy_scale!(Eωo_noise, noise_field, N, scale)
         Et_noise = zeros(TT, (length(grid.to), Ny, Nx))
-        ldiv!(Et_noise, FT, Eωo_noise)
         Et_nl = zeros(TT, (length(grid.to), Ny, Nx))
     else
+        Eωo_noise = nothing
         Et_noise = nothing
         Et_nl = nothing
     end
     TransFree(FT, normfun, responses, grid, xygrid, densityfun,
-              Pto, Eto, Eωo, Pωo, scale, idcs, Et_noise, Et_nl)
+              Pto, Eto, Eωo, Pωo, scale, idcs, noise, Eωo_noise, Et_noise, Et_nl)
 end
 
 function TransFree(grid::Grid.RealGrid, args...; kwargs...)
@@ -730,9 +807,13 @@ function (t::TransFree)(nl, Eωk, z)
     fill!(t.Eωo, 0)
     copy_scale!(t.Eωo, Eωk, length(t.grid.ω), t.scale)
     ldiv!(t.Eto, t.FT, t.Eωo) # transform (ω, ky, kx) -> (t, y, x)
-    # Modified shot-noise: compute field+noise in separate buffer (Et_nl) so the
-    # propagating field (Eto) is never contaminated.
-    if !isnothing(t.Et_noise)
+    # Modified shot-noise: advance the noise to this z ((ω,ky,kx) → (t,y,x)) and compute
+    # field+noise in a separate buffer (Et_nl) so the propagating field (Eto) is never
+    # contaminated.
+    if !isnothing(t.noise)
+        fill!(t.Eωo_noise, 0)
+        copy_scale!(t.Eωo_noise, noise_at!(t.noise, z), length(t.grid.ω), t.scale)
+        ldiv!(t.Et_noise, t.FT, t.Eωo_noise)
         @. t.Et_nl = t.Eto + t.Et_noise
         Et_to_Pt!(t.Pto, t.Et_nl, t.resp, t.densityfun(z), t.idcs)
     else

--- a/src/Processing.jl
+++ b/src/Processing.jl
@@ -819,6 +819,68 @@ envelope(grid::RealGrid, Eω) = Maths.hilbert(FFTW.irfft(Eω, length(grid.t), 1)
 envelope(grid::EnvGrid, Eω) = FFTW.ifft(Eω, 1) .* exp.(im.*grid.ω0.*grid.t)
 
 """
+    withnoise(output)
+    withnoise(output, transform)
+
+Return `output["Eω"]` with the modified shot-noise background restored, i.e.
+`A_s'(z) + A_noise(z)`, ready to be passed to the array methods of [`energy`](@ref),
+[`getIω`](@ref) and friends.
+
+The modified shot-noise model (`shotnoise=:modified`) deliberately excludes the noise field
+from the propagating spectrum, so power read straight from `Eω` is low by construction
+wherever the generated signal is at or below the vacuum level — most obviously when comparing
+against a `shotnoise=:input` run. Restoring the background makes the two models directly
+comparable.
+
+The single-argument method reconstructs the noise from data saved in `output` and therefore
+requires the simulation to have been run with `save_noise=true`. The two-argument method
+takes the `transform` returned by e.g.
+[`prop_capillary_args`](@ref Luna.Interface.prop_capillary_args) and works without it.
+
+!!! note
+    The paper subtracts `P_noise` after restoration because it wants the *generated* power.
+    If the quantity being compared already includes the seed — as it does when comparing
+    against a `:input` run — subtracting again double-counts.
+
+# Examples
+```julia
+out = prop_capillary(a, L, gas, P; ..., shotnoise=:modified, save_noise=true)
+E = Processing.energy(Processing.makegrid(out), Processing.withnoise(out); bandpass=band)
+```
+"""
+function withnoise(output)
+    haskey(output, "noise_field") || error(
+        "output contains no noise field: withnoise requires shotnoise=:modified")
+    haskey(output, "noise_phase") || error(
+        "output contains no \"noise_phase\": re-run with save_noise=true, or pass the "*
+        "transform as a second argument")
+    Eω = output["Eω"]
+    Eω0 = output["noise_field"]
+    Φ = output["noise_phase"]
+    _addnoise(Eω, Eω0, Φ)
+end
+
+function withnoise(output, transform)
+    noise = hasfield(typeof(transform), :noise) ? transform.noise : nothing
+    isnothing(noise) && error(
+        "transform has no noise field: withnoise requires shotnoise=:modified")
+    Eω = output["Eω"]
+    zs = output["z"]
+    Φ = zeros(Float64, (size(noise.Eω0)..., length(zs)))
+    d = ndims(Φ)
+    for (i, z) in enumerate(zs)
+        noise.phase(selectdim(Φ, d, i), z)
+    end
+    _addnoise(Eω, noise.Eω0, Φ)
+end
+
+function _addnoise(Eω, Eω0, Φ)
+    size(Φ) == size(Eω) || error(
+        "saved noise phase has size $(size(Φ)) but Eω has size $(size(Eω))")
+    @. Eω + Eω0 * cis(Φ)
+end
+
+"""
     makegrid(output)
 
 Create an `AbstractGrid` from the `"grid"` dictionary saved in `output`.

--- a/test/test_noise.jl
+++ b/test/test_noise.jl
@@ -123,19 +123,18 @@ end
 end
 
 @testset "Tabulated unitary phase" begin
-    # z-dependent linear operator (pressure gradient): the accumulated phase is tabulated
-    # and must agree with a direct quadrature of imag(linop).
+    # z-dependent linear operators: the accumulated phase is tabulated by adaptive
+    # bisection, and must agree with a direct quadrature of imag(linop) to the tolerance the
+    # refinement was asked for. Luna's own profiles are the awkward cases -- a p0 = 0
+    # gradient has a 1/√z cusp in dp/dz at the entrance and a multi-section fill has a
+    # derivative discontinuity at every junction -- so all of them are exercised here.
     grid = Grid.RealGrid(0.2, 800e-9, (400e-9, 2e-6), 200e-15)
-    coren, _ = Capillary.gradient(:He, 0.2, 5.0, 0.1)
-    mode = Capillary.MarcatiliMode(100e-6, coren; loss=true)
-    linop!, _ = LinearOps.make_linop(grid, mode, grid.referenceλ)
-    phase = LinearOps.unitary_phase(linop!, grid, (length(grid.ω),))
-    @test phase isa LinearOps.TabulatedUnitaryPhase
+    nω = length(grid.ω)
 
-    function refphase(z; n=201) # composite Simpson, n odd
+    function refphase(linop!, z; n=2001) # composite Simpson, n odd
         zs = range(0, z, length=n)
-        buf = Array{ComplexF64}(undef, length(grid.ω))
-        acc = zeros(Float64, length(grid.ω))
+        buf = Array{ComplexF64}(undef, nω)
+        acc = zeros(Float64, nω)
         for (i, zz) in enumerate(zs)
             w = (i == 1 || i == n) ? 1.0 : (iseven(i) ? 4.0 : 2.0)
             linop!(buf, zz)
@@ -144,15 +143,51 @@ end
         acc .* (step(zs)/3)
     end
 
-    φ = zeros(Float64, length(grid.ω))
-    for z in (0.05, 0.13)
-        phase(φ, z)
-        @test maximum(abs, φ .- refphase(z)) < 1e-6
+    linops = Dict(
+        # smooth gradient
+        "gradient" => Capillary.gradient(:He, 0.2, 5.0, 0.5)[1],
+        # p0 = 0: dp/dz diverges as 1/√z at the entrance
+        "cusp" => Capillary.gradient(:He, 0.2, 0.0, 5.0)[1],
+        # multi-section fill: a derivative discontinuity at each junction
+        "kinks" => Capillary.gradient(:He, [0.0, 0.07, 0.13, 0.2], [0.0, 6.0, 1.0, 3.0])[1],
+    )
+    φ = zeros(Float64, nω)
+    for (name, coren) in linops
+        mode = Capillary.MarcatiliMode(100e-6, coren; loss=true)
+        linop!, _ = LinearOps.make_linop(grid, mode, grid.referenceλ)
+        phase = LinearOps.unitary_phase(linop!, grid, (nω,))
+        @test phase isa LinearOps.TabulatedUnitaryPhase
+        # the refinement met the tolerance it was asked for...
+        @test phase.err <= phase.atol
+        # ...and the measured error is a good estimate of the true one, which is what
+        # justifies reporting it. 10x headroom covers the midpoint estimate being slightly
+        # optimistic and the reference quadrature's own error at the cusp/kinks.
+        for z in (0.05, 0.13, 0.2)
+            phase(φ, z)
+            @test maximum(abs, φ .- refphase(linop!, z)) < 10*phase.atol
+        end
     end
-    # the integrator overshoots grid.zmax on its final step, so evaluation past the end of
-    # the table must extrapolate rather than fail
-    phase(φ, 0.21)
-    @test maximum(abs, φ .- refphase(0.21)) < 1e-4
+
+    # a kinked taper, with a static fill. Unlike a gas gradient, whose pressure profile is
+    # clamped beyond the fibre, a taper keeps changing past zmax -- so this is the case that
+    # needs the table to cover the integrator's overshoot with real nodes.
+    afun(z) = z < 0.1 ? 100e-6 : 100e-6 - 40e-6*(z - 0.1)/0.1
+    linop!, _ = LinearOps.make_linop(
+        grid, Capillary.MarcatiliMode(afun, :He, 5.0; loss=true), grid.referenceλ)
+    phase = LinearOps.unitary_phase(linop!, grid, (nω,))
+    @test phase.err <= phase.atol
+    @test phase.z[end] > grid.zmax # the overshoot margin is tabulated, not extrapolated
+    for z in (0.13, 0.2, 0.205)
+        phase(φ, z)
+        @test maximum(abs, φ .- refphase(linop!, z)) < 10*phase.atol
+    end
+    # past the margin it falls back to linear extrapolation rather than failing
+    phase(φ, 0.5)
+    @test all(isfinite, φ)
+    # a tolerance the caller asks for is honoured
+    coarse = LinearOps.unitary_phase(linop!, grid, (nω,); atol=1e-3)
+    @test coarse.err <= 1e-3
+    @test length(coarse.z) < length(phase.z) # ... with fewer nodes
 end
 
 @testset "Multimode modified noise integration" begin
@@ -409,6 +444,24 @@ end
     @test_throws ErrorException Processing.withnoise(out2)
     # ... or the transform, which always works
     @test Processing.withnoise(out2, transform) ≈ E
+end
+
+@testset "Cached resume adopts the recorded noise" begin
+    # The modified model uses the noise at every step, so resuming a cached run with a fresh
+    # draw would splice two realisations together and leave the already-saved planes
+    # inconsistent with the recorded noise field.
+    fpath = joinpath(mktempdir(), "noise_resume.h5")
+    out = prop_capillary(noise_args...; noise_kwargs..., shotnoise=:modified,
+                         rng=Random.MersenneTwister(42), filepath=fpath)
+    saved = out["noise_field"]
+    @test any(!iszero, saved)
+    # setting up again on the same file finds the cache, and must adopt the recorded draw
+    # rather than the different one its own rng would produce
+    _, _, _, transform, _, out2 = Interface.prop_capillary_args(
+        noise_args...; noise_kwargs..., shotnoise=:modified,
+        rng=Random.MersenneTwister(7), filepath=fpath)
+    @test transform.noise.Eω0 == saved
+    @test out2["noise_field"] == saved
 end
 
 @testset "rtol/atol are threaded to the integrator" begin

--- a/test/test_noise.jl
+++ b/test/test_noise.jl
@@ -1,6 +1,6 @@
 using Luna
 import Test: @test, @testset, @test_throws
-import Luna: Fields, Grid, Processing
+import Luna: Fields, Grid, Processing, LinearOps, NonlinearRHS, Capillary, Interface
 import Random
 import Logging
 
@@ -95,6 +95,64 @@ const noise_kwargs = (λ0=800e-9, τfwhm=10e-15, energy=1e-12,
         # Amplitude identical across modes
         @test abs.(nf[:, 1]) ≈ abs.(nf[:, 2])
     end
+end
+
+@testset "Unitary phase and noise propagation" begin
+    grid = Grid.RealGrid(0.1, 800e-9, (200e-9, 4e-6), 400e-15)
+    mode = Capillary.MarcatiliMode(100e-6, :He, 1.0; loss=true)
+    linop, _, _, _ = LinearOps.make_const_linop(grid, mode, grid.referenceλ)
+    # the mode really is lossy, or the "loss is not applied" test below is vacuous
+    @test minimum(real, linop) < 0
+
+    phase = LinearOps.unitary_phase(linop, grid)
+    @test phase isa LinearOps.ConstUnitaryPhase
+    φ = zeros(Float64, length(grid.ω))
+    phase(φ, 0.037)
+    @test φ == imag.(linop) .* 0.037
+
+    nf = Fields.generate_noise_field(grid; rng=Random.MersenneTwister(42))
+    noise = NonlinearRHS.ModifiedNoise(nf, phase, grid)
+    # at z = 0 the noise is exactly the draw, so the "clean input spectrum" property holds
+    @test NonlinearRHS.noise_at!(noise, 0.0) == noise.Eω0
+    # loss is NOT applied: the amplitude is invariant, only the phase advances
+    for z in (0.01, 0.05, 0.1)
+        @test abs.(NonlinearRHS.noise_at!(noise, z)) ≈ abs.(noise.Eω0)
+    end
+    # dispersion IS applied
+    @test !isapprox(NonlinearRHS.noise_at!(noise, 0.1), noise.Eω0)
+end
+
+@testset "Tabulated unitary phase" begin
+    # z-dependent linear operator (pressure gradient): the accumulated phase is tabulated
+    # and must agree with a direct quadrature of imag(linop).
+    grid = Grid.RealGrid(0.2, 800e-9, (400e-9, 2e-6), 200e-15)
+    coren, _ = Capillary.gradient(:He, 0.2, 5.0, 0.1)
+    mode = Capillary.MarcatiliMode(100e-6, coren; loss=true)
+    linop!, _ = LinearOps.make_linop(grid, mode, grid.referenceλ)
+    phase = LinearOps.unitary_phase(linop!, grid, (length(grid.ω),))
+    @test phase isa LinearOps.TabulatedUnitaryPhase
+
+    function refphase(z; n=201) # composite Simpson, n odd
+        zs = range(0, z, length=n)
+        buf = Array{ComplexF64}(undef, length(grid.ω))
+        acc = zeros(Float64, length(grid.ω))
+        for (i, zz) in enumerate(zs)
+            w = (i == 1 || i == n) ? 1.0 : (iseven(i) ? 4.0 : 2.0)
+            linop!(buf, zz)
+            @. acc += w*imag(buf)
+        end
+        acc .* (step(zs)/3)
+    end
+
+    φ = zeros(Float64, length(grid.ω))
+    for z in (0.05, 0.13)
+        phase(φ, z)
+        @test maximum(abs, φ .- refphase(z)) < 1e-6
+    end
+    # the integrator overshoots grid.zmax on its final step, so evaluation past the end of
+    # the table must extrapolate rather than fail
+    phase(φ, 0.21)
+    @test maximum(abs, φ .- refphase(0.21)) < 1e-4
 end
 
 @testset "Multimode modified noise integration" begin
@@ -199,8 +257,11 @@ const anti_stokes_band = (500e-9, 680e-9)  # H₂ vibrational anti-Stokes region
     # Modified model: clean input spectrum (negligible energy in Stokes band at z=0)
     @test E_stokes_mod[1] < 1e-30
 
-    # Both models produce similar Stokes energy at z=L (either from noise-seeded or
-    # stimulated Raman of the pulse's spectral tails)
+    # Both models generate Stokes light. They are NOT expected to agree at z = L in this
+    # low-gain configuration: the traditional model's Stokes band is still dominated by its
+    # own residual input noise floor rather than by generated Stokes, so the two legitimately
+    # differ by orders of magnitude here. The model comparison that does mean something is
+    # in the "Model agreement in the Raman gain regime" testset below.
     @test E_stokes_mod[end] > 0
     @test E_stokes_trad[end] > 0
 
@@ -260,6 +321,104 @@ end
     @test E_s[end] / E_s[1] > 1e10
     # Monotonic growth in the last ~10 z-points (exponential gain regime)
     @test all(diff(E_s[end-9:end]) .> 0)
+end
+
+@testset "Model agreement in the Raman gain regime" begin
+    # Raman gain is phase-insensitive, so the two noise models must give the same Stokes
+    # energy at z = L once real gain (rather than the residual input noise floor) sets the
+    # Stokes level. This is the assertion the comment in "Noise model physics with Raman"
+    # promised but never made; it needs a gain-dominated configuration to mean anything.
+    #
+    # It is also the control for the noise-propagation fix: advancing the noise field under
+    # the unitary linear operator changes phase-insensitive results not at all (measured
+    # ratio 1.0000011 with propagation, 0.9999916 without), while changing Kerr/FWM results
+    # by one to two orders of magnitude — see "Chen & Wise identity: Kerr soliton".
+    gain_args = (100e-6, 0.15, :H2, 20)  # 100 μm, 15 cm, H₂ at 20 bar
+    gain_kwargs = (λ0=800e-9, τfwhm=30e-15, energy=40e-6, trange=1000e-15,
+                   λlims=(200e-9, 4e-6), kerr=false, plasma=false, saveN=11)
+    mod = prop_capillary(gain_args...; gain_kwargs..., shotnoise=:modified,
+                         rng=Random.MersenneTwister(42))
+    trad = prop_capillary(gain_args...; gain_kwargs..., shotnoise=:input,
+                          rng=Random.MersenneTwister(42))
+    E_mod = Processing.energy(mod; bandpass=stokes_band)
+    E_trad = Processing.energy(trad; bandpass=stokes_band)
+    # modified starts clean, traditional starts on its own noise floor
+    @test E_mod[1] < 1e-30
+    @test E_trad[1] > 1e-20
+    # ... and they land on the same Stokes energy
+    @test isapprox(E_mod[end], E_trad[end]; rtol=1e-4)
+end
+
+@testset "Chen & Wise identity: Kerr soliton" begin
+    # `Fields.ShotNoise` and `Fields.generate_noise_field` use the same amplitude formula and
+    # the same `rand` call, so a shared seed gives the two models an identical noise draw.
+    # The modified model then rests on the identity A_s = A_s' + A_noise: with the background
+    # restored, it must reproduce the traditional model field for field. That holds only if
+    # the noise field is advanced along z — with a static noise field this fails by ~50x on
+    # an N = 6 soliton over one period, which is a conservative (no net gain) problem and so
+    # the most sensitive kind. No ensemble is needed: this is deterministic.
+    γ = 0.1
+    β2 = -1e-26
+    τ0 = 280e-15
+    N = 6.0
+    P0 = N^2*abs(β2)/(γ*τ0^2) # fr = 0, so χ3 is the full Kerr nonlinearity
+    L = π*τ0^2/(2*abs(β2))    # one soliton period
+    kw = (λ0=835e-9, τfwhm=(2*log(1 + sqrt(2)))*τ0, power=P0, pulseshape=:sech,
+          λlims=(450e-9, 8e-6), trange=4e-12, raman=false, fr=0.0, saveN=2)
+    function propagate(shotnoise)
+        Eω, grid, linop, transform, FT, output = Interface.prop_gnlse_args(
+            γ, L, [0.0, 0.0, β2]; kw..., shotnoise, rng=Random.MersenneTwister(42))
+        Luna.run(Eω, grid, linop, transform, FT, output;
+                 rtol=1e-8, atol=1e-16, status_period=60)
+        output, transform
+    end
+    ref, _ = propagate(false)
+    trad, _ = propagate(:input)
+    mod, tr = propagate(:modified)
+
+    E0 = ref["Eω"][:, end]
+    # noise-seeded content, as the difference from the noiseless run
+    seeded(E) = maximum(abs.(E .- E0))/maximum(abs.(E0))
+    An = NonlinearRHS.noise_at!(tr.noise, L) # the noise background at z = L
+    d_trad = seeded(trad["Eω"][:, end])
+    d_mod = seeded(mod["Eω"][:, end] .+ An)
+    @test d_trad > 1e-3 # the noise is doing something, i.e. the test has teeth
+    @test 0.5 < d_mod/d_trad < 2.0 # ~50 with a static noise field
+end
+
+@testset "Processing.withnoise" begin
+    out = prop_capillary(noise_args...; noise_kwargs..., shotnoise=:modified,
+                         save_noise=true, rng=Random.MersenneTwister(42))
+    @test haskey(out, "noise_field")
+    @test haskey(out, "noise_phase")
+    E = Processing.withnoise(out)
+    @test size(E) == size(out["Eω"])
+    # at z = 0 the accumulated phase is zero, so the background is exactly the draw
+    @test E[:, 1] ≈ out["Eω"][:, 1] .+ out["noise_field"]
+    # restoring the background adds exactly the vacuum level, whose amplitude does not
+    # change with z (loss is not applied to the noise)
+    @test maximum(abs, E[:, end] .- out["Eω"][:, end]) ≈ maximum(abs, out["noise_field"])
+
+    # the z = 0 draw is always saved, but reconstruction from file needs save_noise=true
+    Eω, grid, linop, transform, FT, out2 = Interface.prop_capillary_args(
+        noise_args...; noise_kwargs..., shotnoise=:modified,
+        rng=Random.MersenneTwister(42))
+    Luna.run(Eω, grid, linop, transform, FT, out2; status_period=60)
+    @test haskey(out2, "noise_field")
+    @test !haskey(out2, "noise_phase")
+    @test_throws ErrorException Processing.withnoise(out2)
+    # ... or the transform, which always works
+    @test Processing.withnoise(out2, transform) ≈ E
+end
+
+@testset "rtol/atol are threaded to the integrator" begin
+    # prop_capillary and prop_gnlse previously offered no way to set integrator tolerances
+    kwargs = (noise_kwargs..., shotnoise=false)
+    loose = prop_capillary(noise_args...; kwargs..., rtol=1e-4)
+    tight = prop_capillary(noise_args...; kwargs..., rtol=1e-10, atol=1e-16)
+    @test loose["Eω"] != tight["Eω"]
+    @test isapprox(loose["Eω"][:, end], tight["Eω"][:, end];
+                   atol=1e-3*maximum(abs, tight["Eω"][:, end]))
 end
 
 Logging.global_logger(old_logger)


### PR DESCRIPTION
## The problem

`shotnoise=:modified` (the default) draws a one-photon-per-mode noise field once and adds it to the field inside the nonlinear operator at every step — but never advances it in `z`. `Et_noise` was precomputed at construction and used unchanged for the whole propagation, in all four transforms.

Holding it constant is exact in the dispersion-free gain model in which Chen & Wise derive their identity `A_s = A_s' + A_noise`. It is not exact in a dispersive medium: in the traditional (`:input`) model the input noise *does* disperse, so once the modified model's noise does not, the two stop being related by that identity. Measured against the exact Bogoliubov result for spontaneous MI on a CW pump, the error is 1.4–6.6× per frequency, worsening toward the MI band edge; in conservative propagation, where there is no net gain to dilute a coherently injected source, it reaches ~50–80×.

Raman results are unaffected either way, which is presumably why this went unnoticed — every motivating example in the paper (Raman Stokes/anti-Stokes asymmetry, thermal phonons, rare-earth ASE) is phase-insensitive. MI/FWM is the opposite: the ±Ω sideband pair must hold a fixed phase relation to the pump, and that relation is exactly what dispersion controls.

## The fix

The noise field is now advanced by the **unitary** part of `linop` only. The rule is scoped by conservativeness, not by "dispersion", because Luna's media have real loss:

| part of `linop` | applied? | why |
|---|---|---|
| dispersion | **yes** | Unitary; the phase evolution of the medium's own vacuum modes. |
| loss | **no** | Fluctuation–dissipation: loss replenishes the vacuum rather than removing it, so the local level stays at one photon per mode. This is also what lets the model seed spontaneous generation in an absorbing medium, "saturating at `P_noise`". |
| gain | **no** | The source already injects fresh vacuum at every `z`, which the homogeneous propagator amplifies over the remaining length — that integral *is* the ASE. Amplifying the noise as well double-counts. |

It is still drawn once and never re-randomised, so results stay step-size independent — which is what the paper's "constant noise field" requirement actually protects. Advancing it with the *full* linearised operator would be worse than doing nothing, since the source term already supplies the nonlinear part.

Luna already passes the full `E + E_noise` to the response, which is the correct all-orders form; that needed no change.

## What changed

| File | Change |
|---|---|
| `src/LinearOps.jl` | `unitary_phase(linop, grid, sz)` returns `Φ(ω, z) = ∫₀ᶻ imag(linop) dz'`. Exact closed form for a constant `linop`; for a `z`-dependent one it is tabulated by adaptive bisection to a measured error tolerance (see **Table accuracy** below). |
| `src/NonlinearRHS.jl` | New `ModifiedNoise` bundling the draw with that propagator, plus `noise_at!`. `TransModeAvg`, `TransRadial`, `TransFree` advance the noise to the current `z`; `TransModal` does it once per RHS evaluation in `reset!`, so its existing per-cubature-point path is untouched. The `noise_field` keyword becomes `noise` and takes the bundle. |
| `src/Processing.jl` | `withnoise(output)` / `withnoise(output, transform)` restore the excluded background, `A_s' + A_noise(z)`, needed before reading power near the vacuum level. |
| `src/Interface.jl` | Builds the bundle where `linop` already exists. New `save_noise` keyword records the realisation in the output. `rtol`/`atol` are threaded to the integrator — previously they could not be set through the interface at all. |
| `docs/src/model/noise.md` | The bullets stating "dispersion acts only on the physical field" and "the noise field is constant … it does not evolve" described the defect as a feature; replaced with the table above and a note that *constant* means **not re-randomised**. |

## Table accuracy

For a `z`-dependent `linop` the phase has to be integrated numerically, so the question is what accuracy that carries. Node placement is driven by a *measured* error, not by a node count picked in advance: the cubic Hermite interpolant that reads the table back is compared, at each candidate interval's midpoint where its error peaks, against the directly integrated value there, and the interval is bisected until that is within `atol` (default 1e-6 rad). The largest surviving error is stored on the object and reported; if `maxdepth`/`maxnodes` stop refinement first, it warns with the error achieved rather than returning something unquantified.

This is worth doing because Luna's `z`-dependent operators are usually *not* smooth. `Capillary.gradient` gives `p(z) = √(p₀² + z/L(p₁² − p₀²))`, which has a `1/√z` cusp in `dp/dz` at the entrance whenever `p₀ = 0`, and a multi-section fill has a derivative discontinuity at every junction. Measured against a fine reference quadrature on a 0.4 m capillary:

| profile | uniform, 401 nodes | adaptive, `atol` = 1e-6 |
|---|---|---|
| gradient 5 → 0.5 bar (smooth) | 4.4e-9 rad | 2.3e-7 rad, **34 nodes** |
| gradient 0 → 5 bar (√ cusp) | 2.4e-5 rad | 9.3e-7 rad, **41 nodes** |
| 3-section fill (kinks) | 5.0e-5 rad | 1.3e-6 rad, **78 nodes** |
| kinked taper | 6.8e-8 rad | 8.3e-7 rad, **55 nodes** |

Putting nodes only where they are needed makes the tables ~10× *smaller* as well as uniformly accurate. A realistic large case — 3 m, 0 → 10 bar fill on a 4097-point grid — needs 193 nodes and 12 MB, built in 0.6 s, at `|Φ(L)|` = 3200 rad, i.e. 3e-10 relative.

The table covers `[0, 1.05·zmax]`, not `[0, zmax]`: `RK45.solve` runs `while tn <= tmax` and so overshoots on its final step, and that step's stages are what the last saved plane is interpolated from. A gas gradient is clamped beyond the fibre so linear extrapolation was exact there, but a taper keeps changing — extrapolating a kinked taper 0.01 m past the end was off by 0.36 rad. `linop!` has to be defined slightly past `zmax` for this, which Luna already requires: `RK45.make_prop!` evaluates it there too.

## Resuming a cached run

The modified model uses the noise at *every* step, so resuming a cached `HDF5Output` with a fresh draw would splice two realisations together mid-fibre. (`:input` is unaffected: its noise enters only the initial condition, so the cached field already carries it.) On finding a `"noise_field"` in the output, the run adopts it for the rest of the propagation and logs that the `rng` argument is being ignored.

## Verification

**N=6 soliton over one period** — conservative, so the most sensitive case. Field-differenced against a noiseless run, background restored:

| seed | `:input` | fixed | static (before) |
|---|---|---|---|
| 42 | 7.96e-3 | 7.65e-3 (**0.96×**) | 4.29e-1 (**53.9×**) |
| 7 | 1.01e-2 | 9.87e-3 (**0.98×**) | 8.36e-1 (**82.6×**) |

Integrator floor 3.0e-5, well below the signal.

**Raman does not move**: H₂, `kerr=false`, Stokes energy ratio to `:input` is 1.0000011 with propagation and 0.9999916 without — the change costs nothing where it is not needed.

**Tabulated phase** agrees with direct quadrature to 3e-9 rad on a gradient-pressure capillary.

**Full suite**: 4380 passed, 1 failed. The failure is `test_fields.jl:388` ("CW fields", `rtol=5e-16`, 20.000000000000014 vs 20.0). I ran the full suite on a clean worktree at `master` and it fails there identically — pre-existing and order-dependent, not caused by this change. Per-testset times match within noise.

## Tests added

- The **Chen & Wise identity** on the N=6 soliton. `Fields.ShotNoise` and `Fields.generate_noise_field` use the same amplitude formula and the same `rand` call, so a shared seed gives both models an identical draw; with the background restored they must agree field for field. Deterministic, no ensemble. This is the test that would have caught the defect (~84 s — the grid has to resolve the compressed spike, or the discretisation floor swamps the signal).
- The **model-agreement assertion** that `test_noise.jl` promised in a comment ("Both models produce similar Stokes energy at z=L") but never made. It needs a gain-dominated configuration to mean anything: at 3 bar / 5 µJ the traditional model's Stokes band is still dominated by its own residual input noise floor and the two legitimately differ by ~100×, so the existing comment is corrected and the real assertion added in a new 20 bar / 15 cm testset.
- Unit tests for the phase machinery: exactness in the constant case, the tabulated `z`-dependent case against a reference quadrature (including the past-`zmax` extrapolation branch), and the amplitude invariance that encodes "loss is not applied".

## For the reviewer

Three things found while verifying, all **pre-existing** and deliberately left alone:

1. **`:input` loses ~37% of its noise energy** to `stepfun`'s `ωwin`/`twin` apodisation, which is re-applied on every accepted step — only ~75% of the time window has `twin == 1`. So `:input` itself runs ~21% low in noise amplitude, and no field-level identity between the two models can be tighter than that outside the flat region. (The `ModifiedNoise` constructor applies `ωwin` once, so the two models at least see the same effective spectral window.)
2. **`:modified` needs many more integrator steps than `:input`** — 2420 vs 295 on a pure-Kerr `prop_gnlse` test — because it injects an undecaying broadband source at every `z`. The per-RHS cost of this change is ~40% in the worst case (pure Kerr, one extra ω→t transform) and ~10% for a plasma+Raman capillary run; wall clock is dominated by the step count, which this change *lowers* (4080 → 2420).
3. For a `z`-dependent `linop`, `RK45.make_prop!` accumulates the **field's own** linear phase by a right-endpoint rectangle rule — O(dz), and not covered by the embedded error estimate. The noise's tabulated phase is now more accurate than the field's; both converge to the same limit as dz → 0.

Also worth a separate issue: `raman=false` does not disable `fr`. `prop_gnlse` computes `χ3 = 4/3·(1−fr)·n2·(ε₀c)`, so with the default `fr = 0.18` and `raman=false`, 18% of the Kerr nonlinearity is silently discarded — an "N = 6" soliton is really N = 5.43 and does not recur. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


