### PR TITLE
Fix phase ramp in Processing.spectral_phase

### DIFF
--- a/src/Processing.jl
+++ b/src/Processing.jl
@@ -639,10 +639,7 @@ function spectral_phase(grid::AbstractGrid, Eω)
     spectral_phase(ω, Eω, τ)
 end
 
-function spectral_phase(ω::AbstractVector, Eω, τ)
-    φ = unwrap(angle.(Eω); dims=1)
-    φ .- ω*τ
-end
+spectral_phase(ω::AbstractVector, Eω, τ) = unwrap(angle.(Eω .* exp.(1im .* ω .* τ)); dims=1)
 
 """
     spectral_phase(output, args...)


### PR DESCRIPTION
Another fix to the same function as in #434. Subtracting the linear phase ramp after unwrapping is simple, but unwrapping the phase with the ramp still present leads to cumulative floating point errors on grids which are largely empty. With this change, the pulse is shifted with a phasor first, then the phase is unwrapped.